### PR TITLE
Bug-Fix: resolving branch name during detached head mode

### DIFF
--- a/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
@@ -17,30 +17,29 @@ class GitBasedVersioning {
     }
 
     /**
-     * Gets the current Git branch from Git or from an environment variable (in the future) with slashes ('/') replaced by
-     * dashes ('-'). If the branch name cannot be determined, throws GradleException. Never empty, never null.
+     * Gets the current Git branch either from TC(for CI builds) or from git rev-parse command(for commandline builds)
+     * with slashes ('/') replaced by dashes ('-'). If the branch name cannot be determined, throws GradleException.
+     * Never empty, never null.
      *
      * @return the current branch name with slashes ('/') replaced by dashes ('-')
      * @throws org.gradle.api.GradleException if the branch name cannot be determined
      */
     static String getGitBranch() throws GradleException {
         String gitBranch
-        String gitBranchTC=System.getenv('teamcity_build_branch')
-        
-        if(gitBranchTC!=null && !gitBranchTC.isEmpty()){
-            gitBranch=gitBranchTC.replace("/", "-")
+        String gitBranchTC = System.getenv('teamcity_build_branch')
+        if(gitBranchTC != null && !gitBranchTC.empty) {
+            gitBranch = gitBranchTC
             println "Branch From TeamCity: "+gitBranch
         }
-        else{
-            gitBranch = getCommandOutput('git rev-parse --abbrev-ref HEAD').replace("/", "-")
+        else {
+            gitBranch = getCommandOutput('git rev-parse --abbrev-ref HEAD')
             println "Branch From Git Commandline: "+gitBranch
         }
 
         if (gitBranch == null || gitBranch.empty) {
             throw new GradleException('Could not determine Git branch name')
         }
-
-        return gitBranch
+        return gitBranch.replace("/", "-")
     }
 
     private static String getCommandOutput(String command) {

--- a/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
@@ -24,7 +24,17 @@ class GitBasedVersioning {
      * @throws org.gradle.api.GradleException if the branch name cannot be determined
      */
     static String getGitBranch() throws GradleException {
-        String gitBranch = getCommandOutput('git rev-parse --abbrev-ref HEAD').replace("/", "-")
+        String gitBranch
+        String gitBranchTC=System.getenv('teamcity_build_branch')
+        
+        if(gitBranchTC!=null && !gitBranchTC.isEmpty()){
+            gitBranch=gitBranchTC.replace("/", "-")
+            println "Branch From TeamCity: "+gitBranch
+        }
+        else{
+            gitBranch = getCommandOutput('git rev-parse --abbrev-ref HEAD').replace("/", "-")
+            println "Branch From Git Commandline: "+gitBranch
+        }
 
         if (gitBranch == null || gitBranch.empty) {
             throw new GradleException('Could not determine Git branch name')


### PR DESCRIPTION
@coolya @DomenikP 
I have made changes to GitBasedVersioning.groovy to handle branch name in case of detached head mode. Would request you to review the changes.
Additional to this change, I have introduced one env parameter (“teamcity_build_branch”) in teamcity whose value is read from configuration parameter: “teamcity.build.branch”.
by default, it’s not possible to access configuration parameters in teamcity builds so it’s necessary to pass it as env parameter.
In GitBasedVersioning plugin, for CI builds the branch name is read from teamcity env parameter and if the build invocation is through command line then branch name is read from git command.
