### PR TITLE
Allow to specify commit count without branch

### DIFF
--- a/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
@@ -52,11 +52,15 @@ class GitBasedVersioning {
         getVersion(getGitBranch(), major, minor)
     }
 
-    static String getVersion(branch, major, minor) {
+    static String getVersion(String branch, major, minor) {
         getVersion(branch, major, minor, getGitCommitCount())
     }
 
-    static String getVersion(branch, major, minor, count) {
+    static String getVersion(major, minor, int count) {
+        getVersion(getGitBranch(), major, minor, count)
+    }
+
+    static String getVersion(branch, major, minor, int count) {
         def hash = getGitShortCommitHash()
         def baseVersion = "$major.$minor.$count.$hash"
         if (branch == 'master' || branch == 'HEAD' /*this happens in detached head situations*/) {


### PR DESCRIPTION
Allow to get a version string without a branch but with a "commit count"
in our case we use the build counter from teamcity for the count input.

I also added some explicit types to the signature to resolve the otherwise ambiguous signatures.