### PR TITLE
Add explicit types in POM helper

### DIFF
--- a/src/main/groovy/de/itemis/mps/gradle/Pom.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/Pom.groovy
@@ -1,3 +1,8 @@
+package de.itemis.mps.gradle
+
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.publish.maven.MavenPom
+
 class Pom {
 
     /**
@@ -5,7 +10,7 @@ class Pom {
      * @param pom the POM node where to add the dependencies
      * @param config the configuration where to get the dependencies from
      */
-    def withDep(pom, config) {
+    def withDep(MavenPom pom, Configuration config) {
         pom.withXml {
             def dependenciesNode = asNode().appendNode('dependencies')
             config.resolvedConfiguration.firstLevelModuleDependencies.each {
@@ -22,7 +27,7 @@ class Pom {
      * @param pom the POM node where to add the dependencies
      * @param config the configuration where to get the dependencies from
      */
-    def withProvidedDep(pom, config) {
+    def withProvidedDep(MavenPom pom, Configuration config) {
         pom.withXml {
             def dependenciesNode = asNode().appendNode('dependencies')
             config.resolvedConfiguration.firstLevelModuleDependencies.each {


### PR DESCRIPTION
Encountered problems in build scripts that the method couldn't get called
I added explicit types here now. Not sure if the "internal" Configuration
is valid to use. But seems to be the only way to get access to resolved
dependencies.