### PR TITLE
Add BundleMacosJdk task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /buildSrc/.gradle
 /buildSrc/build
 /out/
+*.iml

--- a/README.md
+++ b/README.md
@@ -60,6 +60,40 @@ the unpacked RCP artifact, fixes file permissions and creates missing
 symlinks, then creates a DMG image and configures its layout, using the
 background image. Finally, the DMG is copied to `dmgFile`.
 
+## BundleMacosJdk
+
+(Linux/macOS) Creates a .tar.gz by combining an RCP artifact and a JDK.
+This task is intended as a substitute for the macOS-specific CreateDmg
+task.
+
+### Usage
+
+```
+task bundleMacosJdk(type: de.itemis.mps.gradle.BundleMacosJdk) {
+    rcpArtifact file('path/to/RCP.tgz')
+
+    jdkDependency "com.jetbrains.jdk:jdk:${jdkVersion}:osx_x64@tgz"
+    // -or -
+    jdk file('path/to/jdk.tgz')
+
+    outputFile file('output.tar.gz')
+}
+```
+
+Parameters:
+* `rcpArtifact` - the path to the RCP artifact produced by a build script.
+* `jdkDependency` - the coordinates of a JDK in case it's available in
+  a repository and can be resolved as a Gradle dependency.
+* `jdk` - the path to a JDK .tgz file.
+* `outputFile` - the path and file name of the output gzipped tar archive.
+
+### Operation
+
+The task unpacks `rcpArtifact` into a temporary directory, unpacks
+the JDK given by `jdkDependency`/`jdk` under the `jre` subdirectory of
+the unpacked RCP artifact, fixes file permissions and creates missing
+symlinks. Finally, the file is repackaged again as tar/gzip.
+
 ## GenerateLibrariesXml
 
 Generates a `.mps/libraries.xml` file using data from property files.

--- a/src/main/groovy/de/itemis/mps/gradle/BundledScripts.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/BundledScripts.groovy
@@ -1,0 +1,26 @@
+package de.itemis.mps.gradle
+
+import org.gradle.api.GradleException
+
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermissions
+
+class BundledScripts {
+    static void extractScriptsToDir(File dir, String... scriptNames) {
+        def rwxPermissions = PosixFilePermissions.fromString("rwx------")
+
+        for (name in scriptNames) {
+            File file = new File(dir, name)
+            if (!file.parentFile.isDirectory() && ! file.parentFile.mkdirs()) {
+                throw new GradleException("Could not create directory " + file.parentFile)
+            }
+            InputStream resourceStream = BundledScripts.class.getResourceAsStream(name)
+            if (resourceStream == null) {
+                throw new IllegalArgumentException("Resource ${name} was not found")
+            }
+
+            resourceStream.withStream { is -> file.newOutputStream().withStream { os -> os << is } }
+            Files.setPosixFilePermissions(file.toPath(), rwxPermissions)
+        }
+    }
+}

--- a/src/main/resources/de/itemis/mps/gradle/bundle_macos_jdk.sh
+++ b/src/main/resources/de/itemis/mps/gradle/bundle_macos_jdk.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+if [[ $# -ne 4 ]]; then
+  cat <<EOF
+Usage:
+
+  $0 RCP_FILE TMP_DIR JDK_FILE OUT_FILE
+
+1. Extracts RCP_FILE into TMP_DIR
+2. Creates symlinks Contents/bin/*.dylib -> *.jnilib
+3. If JDK_FILE is given, extracts JDK_FILE under Contents/jre/
+4. Sets executable permissions on Contents/MacOS/* and appropriate Contents/bin/ files
+5. Compresses the result into OUT_FILE (tar/gzip)
+
+IMPORTANT: All arguments must use absolute paths because the script changes the current directory several times!
+EOF
+  exit 1
+fi
+
+set -o errexit # Exit immediately on any error
+
+# Arguments
+RCP_FILE="$1"
+TMP_DIR="$2"
+JDK_FILE="$3"
+OUT_FILE="$4"
+
+echo "Unzipping $RCP_FILE to $TMP_DIR..."
+unzip -q -o "$RCP_FILE" -d "$TMP_DIR"
+BUILD_NAME=$(ls "$TMP_DIR")
+CONTENTS="$TMP_DIR/$BUILD_NAME/Contents"
+
+echo 'Creating symlinks from *.jnilib to *.dylib:'
+for f in "$CONTENTS/bin"/*.jnilib; do
+  b="$(basename "$f" .jnilib)"
+  echo "  $f -> $b.dylib"
+  ln -sf "$b.jnilib" "$(dirname "$f")/$b.dylib"
+done
+echo 'Done creating symlinks'
+
+if [[ -n "$JDK_FILE" ]]; then
+  if [[ ! -f "$JDK_FILE" ]]; then
+    echo "$JDK_FILE is not a file"
+    exit 1
+  fi
+  echo "Modifying Info.plist"
+  sed -i -e 's/1.6\*/1.6\+/' "$CONTENTS/Info.plist"
+  sed -i -e 's/NoJavaDistribution/custom-jdk-bundled/' "$CONTENTS/Info.plist"
+
+  # TODO This command appears to be useless, it only inserts a blank line into the file.
+  sed -i -e '/public.app-category.developer-tools/G' "$CONTENTS/Info.plist"
+
+  sed -i -e '/public.app-category.developer-tools/a\'$'\n''<key>NSSupportsAutomaticGraphicsSwitching</key><true/>' "$CONTENTS/Info.plist"
+
+  # sed -i -e seems to work with both GNU sed and OS X sed, with the latter leaving the original file with -e suffix
+  # as a backup.
+  rm -f "$CONTENTS/Info.plist-e"
+  echo "Info.plist has been modified"
+
+  echo "Extracting JDK: $JDK_FILE to $CONTENTS/jre"
+  mkdir -p "$CONTENTS/jre"
+  pushd "$CONTENTS/jre"
+  COPY_EXTENDED_ATTRIBUTES_DISABLE=true COPYFILE_DISABLE=true tar xvf "$JDK_FILE" --exclude='._jdk' || exit 1
+  echo "JDK has been extracted"
+  popd
+fi
+
+chmod a+x "$CONTENTS"/MacOS/*
+chmod a+x "$CONTENTS"/bin/*.py
+chmod a+x "$CONTENTS"/bin/fs*
+chmod a+x "$CONTENTS"/bin/restarter
+
+cd "$TMP_DIR"
+COPY_EXTENDED_ATTRIBUTES_DISABLE=true COPYFILE_DISABLE=true tar czvf "$OUT_FILE" "$BUILD_NAME"
+echo "Bundle created in $OUT_FILE"


### PR DESCRIPTION
Add a task to create a RCP+JDK bundle for macOS but without using macOS-specific tools so that the task runs on Linux.