### PR TITLE
rename getVersion method to prevent dynamic dispatch confusion

### DIFF
--- a/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
@@ -60,7 +60,7 @@ class GitBasedVersioning {
         getVersion(branch, major, minor, getGitCommitCount())
     }
 
-    static String getVersion(String major, String minor, int count) {
+    static String getVersionWithCount(String major, String minor, int count) {
         getVersion(getGitBranch(), major, minor, count)
     }
 


### PR DESCRIPTION
For some reason even when passing `String, String, int` to `getVersion` it would still call the `String,String,String` implementation causing it to interpret the commit count as a branch name.