### PR TITLE
Only register inputs if they exist

### DIFF
--- a/src/main/groovy/de/itemis/mps/gradle/GenerateLibrariesXml.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GenerateLibrariesXml.groovy
@@ -21,7 +21,7 @@ class GenerateLibrariesXml extends DefaultTask {
 
     void setOverrides(Object overrides) {
         this.overrides = project.file(overrides)
-        if (overrides != null) {
+        if (this.overrides != null && this.overrides.exists()) {
             inputs.file(overrides)
         }
     }


### PR DESCRIPTION
The GenerateLibrariesXml file existed none existing files as inputs
in gradle 5.0 this behaviour is no longer valid. I'm adding a check
that it's only added as a input if the file actually exists.