### PR TITLE
Code signing of apps for macOS enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ task buildDmg(type: de.itemis.mps.gradle.CreateDmg) {
 
     backgroundImage file('path/to/background.png')
     dmgFile file('output.dmg')
+
+    signKeyChain file("/path/to/my.keychain-db")
+
+    signKeyChainPassword "my.keychain-db-password"
+
+    signIdentity "my Application ID Name"
 }
 ```
 
@@ -52,13 +58,17 @@ Parameters:
 * `backgroundImage` - the path to the background image.
 * `dmgFile` - the path and file name of the output DMG image. Must end
   with `.dmg`.
+* `signKeyChain (optional)` - the path and file name of the keychain which contains a code signing certificate.
+* `signKeyChainPassword (optional)` - the password which should be use to unlock the keychain.
+* `signIdentity (optional)` - the application ID of the code signing certificate.
 
 ### Operation
 
 The task unpacks `rcpArtifact` into a temporary directory, unpacks
 the JDK given by `jdkDependency`/`jdk` under the `jre` subdirectory of
 the unpacked RCP artifact, fixes file permissions and creates missing
-symlinks, then creates a DMG image and configures its layout, using the
+symlinks. If the additional properties for code singing (`signKeyChain`, `signKeyChainPassword`, `signIdentity`) are defined,
+the application will be signed with the given certificate. Afterwards a DMG image is created and its layout is configured using the
 background image. Finally, the DMG is copied to `dmgFile`.
 
 ## BundleMacosJdk
@@ -78,12 +88,6 @@ task bundleMacosJdk(type: de.itemis.mps.gradle.BundleMacosJdk) {
     jdk file('path/to/jdk.tgz')
 
     outputFile file('output.tar.gz')
-
-    signKeyChain file("/path/to/my.keychain-db")
-
-    signKeyChainPassword "my.keychain-db-password"
-
-    signIdentity "my Application ID Name"
 }
 ```
 
@@ -93,17 +97,13 @@ Parameters:
   a repository and can be resolved as a Gradle dependency.
 * `jdk` - the path to a JDK .tgz file.
 * `outputFile` - the path and file name of the output gzipped tar archive.
-* `signKeyChain (optional)` - the path and file name of the keychain which contains a code signing certificate.
-* `signKeyChainPassword (optional)` - the password which should be use to unlock the keychain.
-* `signIdentity (optional)` - the application ID of the code signing certificate.
 
 ### Operation
 
 The task unpacks `rcpArtifact` into a temporary directory, unpacks
 the JDK given by `jdkDependency`/`jdk` under the `jre` subdirectory of
 the unpacked RCP artifact, fixes file permissions and creates missing
-symlinks. If the additional properties for code singing (`signKeyChain`, `signKeyChainPassword`, `signIdentity`) are defined, the application will
-be signed with the given certificate. Finally, the file is repackaged again as tar/gzip.
+symlinks. Finally, the file is repackaged again as tar/gzip.
 
 ## GenerateLibrariesXml
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ task bundleMacosJdk(type: de.itemis.mps.gradle.BundleMacosJdk) {
     jdk file('path/to/jdk.tgz')
 
     outputFile file('output.tar.gz')
+
+    signKeyChain file("/path/to/my.keychain-db")
+
+    signPw "my.keychain-db-password"
+
+    signAppID "my Application ID Name"
 }
 ```
 
@@ -87,13 +93,17 @@ Parameters:
   a repository and can be resolved as a Gradle dependency.
 * `jdk` - the path to a JDK .tgz file.
 * `outputFile` - the path and file name of the output gzipped tar archive.
+* `signKeyChain (optional)` - the path and file name of the keychain which contains a code signing certificate.
+* `signPw (optional)` - the password which should be use to unlock the keychain.
+* `signAppID (optional)` - the application ID of the code signing certificate.
 
 ### Operation
 
 The task unpacks `rcpArtifact` into a temporary directory, unpacks
 the JDK given by `jdkDependency`/`jdk` under the `jre` subdirectory of
 the unpacked RCP artifact, fixes file permissions and creates missing
-symlinks. Finally, the file is repackaged again as tar/gzip.
+symlinks. If the additional properties for code singing (`signKeyChain`, `signPw`, `signAppID`) are defined, the application will
+be signed with the given certificate. Finally, the file is repackaged again as tar/gzip.
 
 ## GenerateLibrariesXml
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Parameters:
 The task unpacks `rcpArtifact` into a temporary directory, unpacks
 the JDK given by `jdkDependency`/`jdk` under the `jre` subdirectory of
 the unpacked RCP artifact, fixes file permissions and creates missing
-symlinks. If the additional properties for code singing (`signKeyChain`, `signKeyChainPassword`, `signIdentity`) are defined,
+symlinks. If the additional properties for code signing (`signKeyChain`, `signKeyChainPassword`, `signIdentity`) are defined,
 the application will be signed with the given certificate. Afterwards a DMG image is created and its layout is configured using the
 background image. Finally, the DMG is copied to `dmgFile`.
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ task bundleMacosJdk(type: de.itemis.mps.gradle.BundleMacosJdk) {
 
     signKeyChain file("/path/to/my.keychain-db")
 
-    signPw "my.keychain-db-password"
+    signKeyChainPassword "my.keychain-db-password"
 
-    signAppID "my Application ID Name"
+    signIdentity "my Application ID Name"
 }
 ```
 
@@ -94,15 +94,15 @@ Parameters:
 * `jdk` - the path to a JDK .tgz file.
 * `outputFile` - the path and file name of the output gzipped tar archive.
 * `signKeyChain (optional)` - the path and file name of the keychain which contains a code signing certificate.
-* `signPw (optional)` - the password which should be use to unlock the keychain.
-* `signAppID (optional)` - the application ID of the code signing certificate.
+* `signKeyChainPassword (optional)` - the password which should be use to unlock the keychain.
+* `signIdentity (optional)` - the application ID of the code signing certificate.
 
 ### Operation
 
 The task unpacks `rcpArtifact` into a temporary directory, unpacks
 the JDK given by `jdkDependency`/`jdk` under the `jre` subdirectory of
 the unpacked RCP artifact, fixes file permissions and creates missing
-symlinks. If the additional properties for code singing (`signKeyChain`, `signPw`, `signAppID`) are defined, the application will
+symlinks. If the additional properties for code singing (`signKeyChain`, `signKeyChainPassword`, `signIdentity`) are defined, the application will
 be signed with the given certificate. Finally, the file is repackaged again as tar/gzip.
 
 ## GenerateLibrariesXml

--- a/src/main/groovy/de/itemis/mps/gradle/CreateDmg.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/CreateDmg.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.Optional
 
 class CreateDmg extends DefaultTask {
     @InputFile
@@ -19,6 +20,19 @@ class CreateDmg extends DefaultTask {
 
     @OutputFile
     File dmgFile
+
+    @Optional
+    String signPw
+
+    @Optional
+    String signAppID
+
+    @InputFile @Optional
+    File signKeyChain
+
+    def setSignKeyChain(Object file) {
+        this.signKeyChain = project.file(file)
+    }
 
     def setRcpArtifact(Object file) {
         this.rcpArtifact = project.file(file)
@@ -63,7 +77,7 @@ class CreateDmg extends DefaultTask {
             BundledScripts.extractScriptsToDir(scriptsDir, scripts)
             project.exec {
                 executable new File(scriptsDir, 'mpssign.sh')
-                args rcpArtifact, dmgDir, jdk
+                args '-r', rcpArtifact, '-o', dmgDir, '-j', jdk, '-p', signPw, '-k', signKeyChain, '-a', signAppID
                 workingDir scriptsDir
             }
             project.exec {

--- a/src/main/groovy/de/itemis/mps/gradle/CreateDmg.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/CreateDmg.groovy
@@ -67,22 +67,21 @@ class CreateDmg extends DefaultTask {
         }
     }
 
-    def getSigningInfo = [signKeyChainPassword, signKeyChain, signIdentity]
-
     @TaskAction
     def build() {
         String[] scripts = ['mpssign.sh', 'mpsdmg.sh', 'mpsdmg.pl',
                             'Mac/Finder/DSStore/BuddyAllocator.pm', 'Mac/Finder/DSStore.pm']
         File scriptsDir = File.createTempDir()
         File dmgDir = File.createTempDir()
+        def getSigningInfo = [signKeyChainPassword, signKeyChain, signIdentity]
         try {
             BundledScripts.extractScriptsToDir(scriptsDir, scripts)
             project.exec {
                 executable new File(scriptsDir, 'mpssign.sh')
 
-                if(getSigningInfo.every {el != null}) {
+                if(getSigningInfo.every {el -> el != null}) {
                     args '-r', rcpArtifact, '-o', dmgDir, '-j', jdk, '-p', signKeyChainPassword, '-k', signKeyChain, '-i', signIdentity
-                }else if (getSigningInfo.every {el == null}){
+                }else if (getSigningInfo.every {el -> el == null}){
                     args '-r', rcpArtifact, '-o', dmgDir, '-j', jdk
                 }else{
                     throw new IllegalArgumentException("Not all signing paramters set:  signKeyChainPassword: ${getSigningInfo[0]}, signKeyChain: ${getSigningInfo[1]}, signIdentity: ${getSigningInfo[2]} ")

--- a/src/main/groovy/de/itemis/mps/gradle/CreateDmg.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/CreateDmg.groovy
@@ -73,18 +73,18 @@ class CreateDmg extends DefaultTask {
                             'Mac/Finder/DSStore/BuddyAllocator.pm', 'Mac/Finder/DSStore.pm']
         File scriptsDir = File.createTempDir()
         File dmgDir = File.createTempDir()
-        def getSigningInfo = [signKeyChainPassword, signKeyChain, signIdentity]
+        def signingInfo = [signKeyChainPassword, signKeyChain, signIdentity]
         try {
             BundledScripts.extractScriptsToDir(scriptsDir, scripts)
             project.exec {
                 executable new File(scriptsDir, 'mpssign.sh')
 
-                if(getSigningInfo.every {el -> el != null}) {
+                if(signingInfo.every {it != null}) {
                     args '-r', rcpArtifact, '-o', dmgDir, '-j', jdk, '-p', signKeyChainPassword, '-k', signKeyChain, '-i', signIdentity
-                }else if (getSigningInfo.every {el -> el == null}){
+                }else if (signingInfo.every {it == null}){
                     args '-r', rcpArtifact, '-o', dmgDir, '-j', jdk
                 }else{
-                    throw new IllegalArgumentException("Not all signing paramters set:  signKeyChainPassword: ${getSigningInfo[0]}, signKeyChain: ${getSigningInfo[1]}, signIdentity: ${getSigningInfo[2]} ")
+                    throw new IllegalArgumentException("Not all signing paramters set.  signKeyChain: ${getSigningInfo[1]}, signIdentity: ${getSigningInfo[2]} and signKeyChainPassword needs to be set. ")
                 }
                 workingDir scriptsDir
             }

--- a/src/main/resources/de/itemis/mps/gradle/mpssign.sh
+++ b/src/main/resources/de/itemis/mps/gradle/mpssign.sh
@@ -25,7 +25,7 @@ do
     i) SIGN_IDENTITY="$OPTARG";;
     h) echo "$USAGE" 
        exit 0;;
-    \?) echo "illegal option: -$OPTARG usage: /.mpssing.sh -r <rcp_file> -o <output_dir> [-j <jdk_file>] [-p <password keychain> -k <keychain> -i <sign identity>]" >&2
+    \?) echo "illegal option: -$OPTARG usage: $0 -r <rcp_file> -o <output_dir> [-j <jdk_file>] [-p <password keychain> -k <keychain> -i <sign identity>]" >&2
         exit 1;;
     :) echo "option: -$OPTARG requires an argument" >&2
        exit 1;;

--- a/src/main/resources/de/itemis/mps/gradle/mpssign.sh
+++ b/src/main/resources/de/itemis/mps/gradle/mpssign.sh
@@ -14,7 +14,7 @@ IMPORTANT: All arguments must use absolute paths because the script changes the 
 set -o errexit # Exit immediately on any error
 
 # Parse arguments
-while getopts ":r:o:j:p:k:a:h" option; 
+while getopts ":r:o:j:p:k:i:h" option; 
 do
   case "${option}" in
     r) RCP_FILE="$OPTARG";;
@@ -90,7 +90,7 @@ fi
 if [[ -n "$SIGN_PW" && -n "$SIGN_KEY_CHAIN" && -n "$SIGN_IDENTITY" ]]; then
     echo "Signing application $BUILD_NAME"
     echo "key chain: $SIGN_KEY_CHAIN"
-    echo "app id: $SIGN_IDENTITY"
+    echo "sign identity: $SIGN_IDENTITY"
     security unlock-keychain -p $SIGN_PW $SIGN_KEY_CHAIN
     codesign -v --deep -s "$SIGN_IDENTITY" "$OUTPUT_DIR/$BUILD_NAME"
     echo "signing is done"

--- a/src/main/resources/de/itemis/mps/gradle/mpssign.sh
+++ b/src/main/resources/de/itemis/mps/gradle/mpssign.sh
@@ -1,27 +1,43 @@
 #!/bin/bash
-if [[ $# -ne 3 && $# -ne 2 ]]; then
-  cat <<EOF
-Usage:
+USAGE="Usage:
 
-  $0 RCP_FILE OUTPUT_DIR [JDK_FILE]
+/.mpssign.sh -r <rcp_file> -o <output_dir> [-j <jdk_file>] [-p <password keychain> -k <keychain> -a <application id>]
 
+  $0 RCP_FILE OUTPUT_DIR [JDK_FILE] [SIGN_PW] SIGN_KEY_CHAIN SIGN_APP_ID]
 1. Extracts RCP_FILE into OUTPUT_DIR
 2. Creates symlinks Contents/bin/*.dylib -> *.jnilib
-3. If JDK_FILE is given, extracts JDK_FILE under Contents/jre/
+3. Extracts JDK_FILE under Contents/jre/
 4. Builds help indices using hiutil if help is present under Contents/Resources/
 5. Sets executable permissions on Contents/MacOS/* and appropriate Contents/bin/ files
-
+6. If given, signs the application with the passed SIGN_PW, SIGN_KEY_CHAIN and SIGN_APP_ID
 IMPORTANT: All arguments must use absolute paths because the script changes the current directory several times!
-EOF
-  exit 1
-fi
-
+"
 set -o errexit # Exit immediately on any error
 
-# Arguments
-RCP_FILE="$1"
-OUTPUT_DIR="$2"
-JDK_FILE="$3"
+# Parse arguments
+while getopts ":r:o:j:p:k:a:h" option; 
+do
+  case "${option}" in
+    r) RCP_FILE="$OPTARG";;
+    o) OUTPUT_DIR="$OPTARG";;
+    j) JDK_FILE="$OPTARG";;
+    p) SIGN_PW="$OPTARG";;
+    k) SIGN_KEY_CHAIN="$OPTARG";;
+    a) SIGN_APP_ID="$OPTARG";;
+    h) echo "$USAGE" 
+       exit 0;;
+    \?) echo "illegal option: -$OPTARG usage: /.mpssing.sh -r <rcp_file> -o <output_dir> [-j <jdk_file>] [-p <password keychain>] [-k <keychain>] [-a <application id>]" >&2
+        exit 1;;
+    :) echo "option: -$OPTARG requires an argument" >&2
+       exit 1;;
+  esac
+done
+shift $((OPTIND -1)) #remove options that have already been handled from $@
+
+if [[ -z "$RCP_FILE" || -z "$OUTPUT_DIR" ]]; then
+  echo "$USAGE"
+  exit 1
+fi
 
 echo "Unzipping $RCP_FILE to $OUTPUT_DIR..."
 unzip -q -o "$RCP_FILE" -d "$OUTPUT_DIR"
@@ -71,13 +87,19 @@ if [[ -d "$HELP_DIR" ]]; then
     hiutil -Cagvf "$HELP_DIR/search.helpindex" "$HELP_DIR"
 fi
 
-# Make sure JetBrainsMacApplication.p12 is imported into local KeyChain
-#security unlock-keychain -p <password> /Users/builduser/Library/Keychains/login.keychain
-#codesign -v --deep -s "Developer ID Application: JetBrains" "$OUTPUT_DIR/$BUILD_NAME"
-#echo "signing is done"
-#echo "check sign"
-#codesign -v "$OUTPUT_DIR/$BUILD_NAME" -vvvvv
-#echo "check sign done"
+# Make sure your certificate is imported into local KeyChain
+if [[ -n "$SIGN_PW" && -n "$SIGN_KEY_CHAIN" && -n "$SIGN_APP_ID" ]]; then
+    echo "Signing application $BUILD_NAME"
+    echo "pw: $JDK_FILE"
+    echo "key chain: $SIGN_KEY_CHAIN"
+    echo "app id: $SIGN_APP_ID"
+    security unlock-keychain -p $SIGN_PW $SIGN_KEY_CHAIN
+    codesign -v --deep -s "$SIGN_APP_ID" "$OUTPUT_DIR/$BUILD_NAME"
+    echo "signing is done"
+    echo "check sign"
+    codesign -v "$OUTPUT_DIR/$BUILD_NAME" -vvvvv
+    echo "check sign done"
+fi
 
 chmod a+x "$CONTENTS"/MacOS/*
 chmod a+x "$CONTENTS"/bin/*.py


### PR DESCRIPTION
This implementations gives the possibility to use the already existing custom  `createDmg` task to  [sign an application](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Introduction/Introduction.html) with a specific code signing certificate before the .dmg file is created.

### Precondition for using the feature
* keyChain is setup on the machine where the code is executed
* code signing cert. is installed

### How to use the adapted **createDmg** task

```
task build_dmg(type: CreateDmg ) {
   description "Main task to build macOS app"
   rcpArtifact rootProject.file('artifacts/myMacOs.zip')
   jdkDependency "com.jetbrains.jdk:jdk:8u112b408.4:osx_x64@tgz"
   backgroundImage rootProject.file('my image')
   dmgFile rootProject.file('artifacts/myApp.dmg')
   signKeyChainPassword "myPw"
   signIdentity "myAppId"
   signKeyChain new File("/Users/me/Library/Keychains/customCodeSign.keychain-db")
}

```

**The changes contain**
* enabled possibility to use code signing for macOS
* added parameter parsing using getopts
* updated usage info

CreateDmg.groovy:
* added optional task properties
* new properties are used for code signing feature of mspsign.sh