### PR TITLE
Add maven central to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Add the following `buildscript` block to your build script:
 buildscript {
     repositories {
         maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
Maven central is required to to resolve the kotlin stdlib that we are using now.