### PR TITLE
git versioning: add method to check if git is available

### DIFF
--- a/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
@@ -12,7 +12,7 @@ class GitBasedVersioning {
     static boolean isGitVersioningAvailable() {
         try {
             String output = getCommandOutput("git --version")
-            return output.contains("2.")
+            return output.startsWith("git version 2")
         } catch (ignored) {
             return false
         }

--- a/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
@@ -4,6 +4,20 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.GradleException
 
 class GitBasedVersioning {
+
+
+    /**
+     * Checks whenever git based versioning is available.
+     * */
+    static boolean isGitVersioningAvailable() {
+        try {
+            String output = getCommandOutput("git --version")
+            return output.contains("2.")
+        } catch (ignored) {
+            return false
+        }
+    }
+
     static String getGitShortCommitHash() {
         return getCommandOutput('git rev-parse --short HEAD').substring(0,7)
     }


### PR DESCRIPTION
Added a helper method to check if git is available so that build scripts can handle this case gracefully instead of catching the exceptions thrown form the underlying API. 