### PR TITLE
Fix parameter handling for win / fields in Plugin data class

### DIFF
--- a/project-loader/src/main/kotlin/Args.kt
+++ b/project-loader/src/main/kotlin/Args.kt
@@ -5,9 +5,9 @@ import com.xenomachina.argparser.default
 import java.io.File
 
 private fun <T> splitAndCreate(str: String, creator: (String, String) -> T): T {
-    val split = str.split(":")
+    val split = str.split("::")
     if (split.size < 2) {
-        throw RuntimeException("string if not of the right format. Expected <key>:<value>")
+        throw RuntimeException("string if not of the right format. Expected <key>::<value>")
     }
     return creator(split[0], split[1])
 }
@@ -23,11 +23,11 @@ private fun toPlugin(str: String) = splitAndCreate(str, ::Plugin)
 open class Args(parser: ArgParser) {
 
     val plugins by parser.adding("--plugin",
-            help = "plugin to to load. The format is --plugin=<path>:<id>")
+            help = "plugin to to load. The format is --plugin=<path>::<id>")
     { toPlugin(this) }
 
     val macros by parser.adding("--macro",
-            help = "macro to define. The format is --macro=<name>:<value>")
+            help = "macro to define. The format is --macro=<name>::<value>")
     { toMacro(this) }
 
     val pluginLocation by parser.storing("--plugin-location",

--- a/project-loader/src/main/kotlin/Loader.kt
+++ b/project-loader/src/main/kotlin/Loader.kt
@@ -8,8 +8,8 @@ import org.apache.log4j.Logger
 import java.io.File
 
 data class Plugin(
-        val path: String,
-        val id: String
+        val id: String,
+        val path: String
 )
 
 data class Macro(

--- a/src/main/kotlin/de/itemis/mps/gradle/Common.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/Common.kt
@@ -37,7 +37,7 @@ fun argsFromBaseExtension(extensions: BasePluginExtensions): MutableList<String>
     val prj = sequenceOf("--project=${projectLocation.absolutePath}")
 
     return sequenceOf(pluginLocation,
-            extensions.plugins.map { "--plugin=${it.id}:${it.path}" }.asSequence(),
-            extensions.macros.map { "--macro=${it.name}:${it.value}" }.asSequence(),
+            extensions.plugins.map { "--plugin=${it.id}::${it.path}" }.asSequence(),
+            extensions.macros.map { "--macro=${it.name}::${it.value}" }.asSequence(),
             prj).flatten().toMutableList()
 }

--- a/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
@@ -19,9 +19,10 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.run {
             val extension = extensions.create("modelcheck", ModelCheckPluginExtensions::class.java)
-            val mpsLocation = extension.mpsLocation ?: File(project.buildDir, "mps")
 
             afterEvaluate {
+                val mpsLocation = extension.mpsLocation ?: File(project.buildDir, "mps")
+
                 val mpsVersion = extension
                         .mpsConfig
                         .resolvedConfiguration


### PR DESCRIPTION
- init mpsLocation in afterEvaluate{} to use buildDir value set in build script
- use "::" as delimiter to allow win paths in values (i.e. 'C:\')
- changed fields order in Plugin data class to parse plugins data correctly