### PR TITLE
don't attach branch prefix to version for builds on maintenance branches

### DIFF
--- a/execute-generators/build.gradle.kts
+++ b/execute-generators/build.gradle.kts
@@ -1,3 +1,4 @@
+import de.itemis.mps.gradle.GitBasedVersioning
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 
@@ -28,7 +29,10 @@ val kotlinVersion: String by project
 val pluginVersion = "2"
 
 version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity")) {
-    de.itemis.mps.gradle.GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
+    val fullVersion = GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
+    // maintenance builds for specific MPS versions should be published without branch prefix, so that they can be
+    // resolved as dependency from the gradle plugin using version spec "de.itemis.mps:modelcheck:$mpsVersion+"
+    GitBasedVersioning.stripMaintenancePrefix(fullVersion)
 } else {
     "$mpsVersion.$pluginVersion-SNAPSHOT"
 }

--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -1,3 +1,4 @@
+import de.itemis.mps.gradle.GitBasedVersioning
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 import java.net.URI
@@ -26,7 +27,10 @@ val mpsVersion: String by project
 val pluginVersion = "2"
 
 version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity")) {
-    de.itemis.mps.gradle.GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
+    val fullVersion = GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
+    // maintenance builds for specific MPS versions should be published without branch prefix, so that they can be
+    // resolved as dependency from the gradle plugin using version spec "de.itemis.mps:modelcheck:$mpsVersion+"
+    GitBasedVersioning.stripMaintenancePrefix(fullVersion)
 } else {
     "$mpsVersion.$pluginVersion-SNAPSHOT"
 }

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -1,3 +1,4 @@
+import de.itemis.mps.gradle.GitBasedVersioning
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -19,7 +20,10 @@ val nexusPassword: String? by project
 val pluginVersion = "1"
 
 version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity")) {
-    de.itemis.mps.gradle.GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
+    val fullVersion = GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
+    // maintenance builds for specific MPS versions should be published without branch prefix, so that they can be
+    // resolved as dependency from the gradle plugin using version spec "de.itemis.mps:modelcheck:$mpsVersion+"
+    GitBasedVersioning.stripMaintenancePrefix(fullVersion)
 } else {
     "$mpsVersion.$pluginVersion-SNAPSHOT"
 }

--- a/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
@@ -85,6 +85,20 @@ class GitBasedVersioning {
             return baseVersion
         }
 
-        return branch + '.' + baseVersion
+        return "$branch.$baseVersion"
+    }
+
+    /**
+     * Convenience method for creating versions without maintenance branch prefix (i.e. if branch starts with 'maintenance' or 'mps')
+     *
+     * @param version
+     * @return
+     */
+    static String stripMaintenancePrefix(String version) {
+        if (version.startsWith("maintenance") || version.startsWith("mps")) {
+            version.substring(version.indexOf('.'))
+        } else {
+            version
+        }
     }
 }


### PR DESCRIPTION
This allows to publish de.itemis.mps.(execute-generators|modelcheck|project-loader) on maintenance branches without branch prefix, so that these published artifacts can be resolved by simply using de.itemis.mps:modelcheck:$mpsVersion version string.