### PR TITLE
use one method for computing version w/o maintenance prefix

### DIFF
--- a/execute-generators/build.gradle.kts
+++ b/execute-generators/build.gradle.kts
@@ -29,10 +29,9 @@ val kotlinVersion: String by project
 val pluginVersion = "2"
 
 version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity")) {
-    val fullVersion = GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
     // maintenance builds for specific MPS versions should be published without branch prefix, so that they can be
     // resolved as dependency from the gradle plugin using version spec "de.itemis.mps:modelcheck:$mpsVersion+"
-    GitBasedVersioning.stripMaintenancePrefix(fullVersion)
+    GitBasedVersioning.getVersionWithoutMaintenancePrefix(mpsVersion, pluginVersion)
 } else {
     "$mpsVersion.$pluginVersion-SNAPSHOT"
 }

--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -27,10 +27,9 @@ val mpsVersion: String by project
 val pluginVersion = "2"
 
 version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity")) {
-    val fullVersion = GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
     // maintenance builds for specific MPS versions should be published without branch prefix, so that they can be
     // resolved as dependency from the gradle plugin using version spec "de.itemis.mps:modelcheck:$mpsVersion+"
-    GitBasedVersioning.stripMaintenancePrefix(fullVersion)
+    GitBasedVersioning.getVersionWithoutMaintenancePrefix(mpsVersion, pluginVersion)
 } else {
     "$mpsVersion.$pluginVersion-SNAPSHOT"
 }

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -20,10 +20,9 @@ val nexusPassword: String? by project
 val pluginVersion = "1"
 
 version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity")) {
-    val fullVersion = GitBasedVersioning.getVersion(mpsVersion, pluginVersion)
     // maintenance builds for specific MPS versions should be published without branch prefix, so that they can be
     // resolved as dependency from the gradle plugin using version spec "de.itemis.mps:modelcheck:$mpsVersion+"
-    GitBasedVersioning.stripMaintenancePrefix(fullVersion)
+    GitBasedVersioning.getVersionWithoutMaintenancePrefix(mpsVersion, pluginVersion)
 } else {
     "$mpsVersion.$pluginVersion-SNAPSHOT"
 }

--- a/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GitBasedVersioning.groovy
@@ -89,16 +89,18 @@ class GitBasedVersioning {
     }
 
     /**
-     * Convenience method for creating versions without maintenance branch prefix (i.e. if branch starts with 'maintenance' or 'mps')
+     * Convenience method for creating version without maintenance branch prefix (i.e. if branch starts with 'maintenance' or 'mps')
      *
-     * @param version
+     * @param major
+     * @param minor
      * @return
      */
-    static String stripMaintenancePrefix(String version) {
-        if (version.startsWith("maintenance") || version.startsWith("mps")) {
-            version.substring(version.indexOf('.'))
+    static String getVersionWithoutMaintenancePrefix(String major, String minor) {
+        def branch = getGitBranch()
+        if (branch.startsWith("maintenance") || branch.startsWith("mps")) {
+            getVersion("HEAD", major, minor)
         } else {
-            version
+            getVersion(major, minor)
         }
     }
 }


### PR DESCRIPTION
This fixes the bug introduced by the merge of #44 and simplifies computation of version w/o maintenance info by using only one method.