### PR TITLE
modelcheck: add support for JUnit XML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ Parameters:
 * `debug` - optionally allows to start the JVM that is used to load MPS project with a debugger. Setting it to `true` will cause
   the started JVM to suspend until a debugger is attached. Useful for debugging classloading problems or exceptions during
   the build.
+* `junitFile` - allows storing the the results of the model check as a JUnit XML file. The file will  contain one
+  Testcase for each model that was checked. If the model check reported an error for the model the testcase will fail
+  and he message of the model checking error will be reported.
   
 ### Additional Plugins 
 

--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -24,7 +24,7 @@ val nexusPassword: String? by project
 val kotlinArgParserVersion: String by project
 val mpsVersion: String by project
 
-val pluginVersion = "2"
+val pluginVersion = "3"
 
 version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity")) {
     // maintenance builds for specific MPS versions should be published without branch prefix, so that they can be
@@ -40,6 +40,7 @@ val mpsConfiguration = configurations.create("mps")
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation("com.xenomachina:kotlin-argparser:$kotlinArgParserVersion")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.+")
     mpsConfiguration("com.jetbrains:mps:$mpsVersion")
     compileOnly(mpsConfiguration.resolve().map { zipTree(it)  }.first().matching { include("lib/*.jar", "plugins/modelchecker/**/*.jar", "plugins/http-support/**/*.jar")})
     implementation(project(":project-loader"))

--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -189,7 +189,7 @@ fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
         errorCollector.result.map { printResult(it, project, args) }
 
         if (args.xmlFile != null) {
-            writeJuniXml(project.projectModels, errorCollector.result, project, File(args.xmlFile!!))
+            writeJunitXml(project.projectModels, errorCollector.result, project, File(args.xmlFile!!))
         }
     }
 

--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -86,10 +86,14 @@ fun printResult(item: IssueKindReportItem, project: Project, args: ModelCheckArg
 }
 
 
-fun writeJunitXml(models: Iterable<SModel>, results: Iterable<IssueKindReportItem>, project: Project, file: File) {
+fun writeJunitXml(models: Iterable<SModel>,
+                  results: Iterable<IssueKindReportItem>,
+                  project: Project,
+                  warnAsErrors: Boolean,
+                  file: File) {
 
     val allErrors = results.filter {
-        it.severity == MessageStatus.ERROR
+        it.severity == MessageStatus.ERROR || (warnAsErrors && it.severity == MessageStatus.WARNING)
     }
     val errorsPerModel = allErrors
             .filter {
@@ -189,7 +193,7 @@ fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
         errorCollector.result.map { printResult(it, project, args) }
 
         if (args.xmlFile != null) {
-            writeJunitXml(project.projectModels, errorCollector.result, project, File(args.xmlFile!!))
+            writeJunitXml(project.projectModels, errorCollector.result, project, args.warningAsError, File(args.xmlFile!!))
         }
     }
 

--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -1,15 +1,16 @@
 package de.itemis.mps.gradle.modelcheck
 
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.default
 import com.xenomachina.argparser.mainBody
+import de.itemis.mps.gradle.junit.*
 import de.itemis.mps.gradle.project.loader.Args
 import de.itemis.mps.gradle.project.loader.executeWithProject
 import jetbrains.mps.checkers.*
 import jetbrains.mps.errors.MessageStatus
 import jetbrains.mps.errors.item.IssueKindReportItem
 import jetbrains.mps.ide.httpsupport.runtime.base.HttpSupportUtil
-import jetbrains.mps.ide.modelchecker.platform.actions.ModelCheckerIssueFinder
-import jetbrains.mps.ide.modelchecker.platform.actions.ModelCheckerSettings
 import jetbrains.mps.ide.modelchecker.platform.actions.UnresolvedReferencesChecker
 import jetbrains.mps.progress.EmptyProgressMonitor
 import jetbrains.mps.project.Project
@@ -18,6 +19,9 @@ import jetbrains.mps.smodel.SModelStereotype
 import jetbrains.mps.typesystemEngine.checker.TypesystemChecker
 import jetbrains.mps.util.CollectConsumer
 import org.apache.log4j.Logger
+import org.jetbrains.mps.openapi.model.SModel
+import java.io.File
+import kotlin.test.fail
 
 private val logger = Logger.getLogger("de.itemis.mps.gradle.generate")
 
@@ -28,6 +32,7 @@ class ModelCheckArgs(parser: ArgParser) : Args(parser) {
             help = "list of modules to check")
     val warningAsError by parser.flagging("--warning-as-error", help = "treat model checker warning as errors")
     val dontFailOnError by parser.flagging("--error-no-fail", help = "report errors but don't fail the build")
+    val xmlFile by parser.storing("--result-file", help = "stores the result as an JUnit xml file").default<String?>(null)
 }
 
 fun printInfo(msg: String) {
@@ -54,8 +59,8 @@ fun printResult(item: IssueKindReportItem, project: Project, args: ModelCheckArg
 
     val err = ::printError
 
-    val print = fun (severity: MessageStatus, msg: String) {
-        when(severity) {
+    val print = fun(severity: MessageStatus, msg: String) {
+        when (severity) {
             MessageStatus.OK -> info(msg)
             MessageStatus.WARNING -> warn(msg)
             MessageStatus.ERROR -> err(msg)
@@ -80,7 +85,70 @@ fun printResult(item: IssueKindReportItem, project: Project, args: ModelCheckArg
     }
 }
 
-fun modelCheckProject(args: ModelCheckArgs, project: Project) : Boolean {
+
+fun writeJuniXml(models: Iterable<SModel>, results: Iterable<IssueKindReportItem>, project: Project, file: File) {
+
+    val allErrors = results.filter {
+        it.severity == MessageStatus.ERROR
+    }
+    val errorsPerModel = allErrors
+            .filter {
+                val path = IssueKindReportItem.PATH_OBJECT.get(it)
+                path is IssueKindReportItem.PathObject.ModelPathObject || path is IssueKindReportItem.PathObject.NodePathObject
+            }.groupBy {
+                when (val path = IssueKindReportItem.PATH_OBJECT.get(it)) {
+                    is IssueKindReportItem.PathObject.ModelPathObject -> {
+                        path.resolve(project.repository)!!
+                    }
+                    is IssueKindReportItem.PathObject.NodePathObject -> {
+                        val node = path.resolve(project.repository)
+                        node.model!!
+
+                    }
+                    else -> fail("unexpected item type")
+                }
+            }
+
+    val testcases = models.map {
+        val errors = errorsPerModel.getOrDefault(it, emptyList())
+
+        fun reportItemToContent(item: IssueKindReportItem): Failure {
+            return when (val path = IssueKindReportItem.PATH_OBJECT.get(item)) {
+                is IssueKindReportItem.PathObject.ModelPathObject -> {
+                    val model = path.resolve(project.repository)!!
+                    val message = "${item.message} [${model.name.longName}]"
+                    Failure(message = message, content = message)
+                }
+                is IssueKindReportItem.PathObject.NodePathObject -> {
+                    val node = path.resolve(project.repository)
+                    val url = HttpSupportUtil.getURL(node)
+                    val message = "${item.message} [$url]"
+                    Failure(message = message, content = message)
+                }
+                else -> fail("unexpected issue kind")
+            }
+        }
+
+        Testcase(name = it.name.simpleName,
+                classname = it.name.longName,
+                status = if (errors.isEmpty()) "successful" else "failed",
+                failures = errors.map(::reportItemToContent))
+    }
+
+    val testsuites = Testsuites(errors = errorsPerModel.size,
+            name = "model check",
+            tests = models.count(),
+            testsuites = listOf(Testsuite(name = "model checking",
+                    testcases = testcases,
+                    id = 1,
+                    tests = models.count())))
+
+
+    val xmlMapper = XmlMapper()
+    xmlMapper.writeValue(file, testsuites)
+}
+
+fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
 
     // see ModelCheckerSettings.getSpecificCheckers for details
     // we do not call into that class because we don't want to load the settings from the user
@@ -119,6 +187,10 @@ fun modelCheckProject(args: ModelCheckArgs, project: Project) : Boolean {
 
         // We need read access here to resolve the node pointers in the report items
         errorCollector.result.map { printResult(it, project, args) }
+
+        if (args.xmlFile != null) {
+            writeJuniXml(project.projectModels, errorCollector.result, project, File(args.xmlFile!!))
+        }
     }
 
     val hasErrors = if (args.warningAsError) {
@@ -135,7 +207,7 @@ fun main(args: Array<String>) = mainBody {
     val parsed = ArgParser(args).parseInto(::ModelCheckArgs)
     var hasErrors = true
     try {
-        hasErrors = executeWithProject(parsed) { project ->  modelCheckProject(parsed, project) }
+        hasErrors = executeWithProject(parsed) { project -> modelCheckProject(parsed, project) }
     } catch (ex: java.lang.Exception) {
         logger.fatal("error model checking", ex)
     } catch (t: Throwable) {

--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -86,7 +86,7 @@ fun printResult(item: IssueKindReportItem, project: Project, args: ModelCheckArg
 }
 
 
-fun writeJuniXml(models: Iterable<SModel>, results: Iterable<IssueKindReportItem>, project: Project, file: File) {
+fun writeJunitXml(models: Iterable<SModel>, results: Iterable<IssueKindReportItem>, project: Project, file: File) {
 
     val allErrors = results.filter {
         it.severity == MessageStatus.ERROR

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8", version = kotlinVersion))
     mpsConfiguration("com.jetbrains:mps:$mpsVersion")
     implementation("com.xenomachina:kotlin-argparser:$kotlinArgParserVersion")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.+")
     compileOnly(mpsConfiguration.resolve().map { zipTree(it)  }.first().matching { include("lib/*.jar")})
 }
 

--- a/project-loader/src/main/kotlin/JUnit.kt
+++ b/project-loader/src/main/kotlin/JUnit.kt
@@ -1,0 +1,105 @@
+package de.itemis.mps.gradle.junit
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.dataformat.xml.annotation.*
+
+data class Skipped(@JacksonXmlProperty(isAttribute = true)
+                   val message: String,
+                   @field:JacksonXmlCData()
+                   @field:JacksonXmlText() val content: String)
+
+data class Error(@field:JacksonXmlProperty(isAttribute = true)
+                 val message: String,
+                 @field:JacksonXmlProperty(isAttribute = true)
+                 val type: String? = null,
+                 @field:JacksonXmlCData()
+                 @field:JacksonXmlText() val content: String)
+
+
+data class Failure(@field:JacksonXmlProperty(isAttribute = true)
+                   val message: String,
+                   @field:JacksonXmlProperty(isAttribute = true)
+                   val type: String? = null,
+                   @field:JacksonXmlCData()
+                   @field:JacksonXmlText() val content: String)
+
+data class SystemOut(@field:JacksonXmlText()
+                     @field:JacksonXmlCData()
+                     val content: String)
+
+data class SystemErr(@field:JacksonXmlText()
+                     @field:JacksonXmlCData()
+                     val content: String)
+
+
+data class Testcase(
+        @field:JacksonXmlProperty(isAttribute = true)
+        val name: String,
+        @field:JacksonXmlProperty(isAttribute = true)
+        val classname: String,
+        @field:JacksonXmlProperty(isAttribute = true)
+        val assertions: Int? = null,
+        @field:JacksonXmlProperty(isAttribute = true)
+        val status: String? = null,
+        @field:JacksonXmlProperty(isAttribute = true)
+        val time: String? = null,
+        @field:JacksonXmlElementWrapper(useWrapping = false)
+        @field:JacksonXmlProperty(localName = "skipped")
+        @field:JsonInclude(JsonInclude.Include.NON_NULL)
+        val skipped: Skipped? = null,
+        @field:JacksonXmlElementWrapper(useWrapping = false)
+        @field:JacksonXmlProperty(localName = "error")
+        val errors: List<Error> = emptyList(),
+        @field:JacksonXmlElementWrapper(useWrapping = false)
+        @field:JacksonXmlProperty(localName = "failure")
+        val failures: List<Failure> = emptyList(),
+        @field:JacksonXmlElementWrapper(useWrapping = false)
+        @field:JacksonXmlProperty(localName = "system-out")
+        val systemOuts: List<SystemOut> = emptyList(),
+        @field:JacksonXmlElementWrapper(useWrapping = false)
+        @field:JacksonXmlProperty(localName = "system-err")
+        val systemErrors: List<SystemErr> = emptyList()
+        )
+
+
+data class Testsuite(@field:JacksonXmlProperty(isAttribute = true)
+                     val name: String,
+                     @field:JacksonXmlProperty(isAttribute = true)
+                     val tests: Int,
+                     @field:JacksonXmlProperty(isAttribute = true)
+                     val disabled: Int? = null,
+                     @field:JacksonXmlProperty(isAttribute = true)
+                     val errors: Int? = null,
+                     @field:JacksonXmlProperty(isAttribute = true)
+                     val failures: Int? = null,
+                     @field:JacksonXmlProperty(isAttribute = true)
+                     val id: Int,
+                     @field:JacksonXmlProperty(localName = "package", isAttribute = true)
+                     val pkg: String? = null,
+                     @field:JacksonXmlProperty(isAttribute = true)
+                     val skipped: Int? = null,
+                     @field:JacksonXmlProperty(isAttribute = true)
+                     val time: Int? = null,
+                     @field:JacksonXmlProperty(isAttribute = true)
+                     val timestamp: String? = null,
+                     @field:JacksonXmlElementWrapper(useWrapping = false)
+                     @field:JacksonXmlProperty(localName = "testcase")
+                     val testcases: List<Testcase>
+)
+
+@JacksonXmlRootElement(localName = "testsuites")
+data class Testsuites(@field:JacksonXmlProperty(isAttribute = true)
+                      val disabled: Int = 0,
+                      @field:JacksonXmlProperty(isAttribute = true)
+                      val errors: Int = 0,
+                      @field:JacksonXmlProperty(isAttribute = true)
+                      val failures: Int = 0,
+                      @field:JacksonXmlProperty(isAttribute = true)
+                      val name: String,
+                      @field:JacksonXmlProperty(isAttribute = true)
+                      val tests: Int,
+                      @field:JacksonXmlElementWrapper(useWrapping = false,localName = "testsuite")
+                      @field:JacksonXmlProperty(localName = "testsuite")
+                      val testsuites: List<Testsuite>
+)
+

--- a/project-loader/src/main/kotlin/Loader.kt
+++ b/project-loader/src/main/kotlin/Loader.kt
@@ -74,7 +74,7 @@ fun <T> executeWithProject(project: File,
                            buildNumber: String? = null,
                            action: (Project) -> T): T {
 
-    val propertyOverrides = mutableListOf<Pair<String,String>>()
+    val propertyOverrides = mutableListOf<Pair<String,String?>>()
 
     if (pluginLocation != null) {
         logger.info("overriding plugin location with: ${pluginLocation.absolutePath}")
@@ -123,7 +123,12 @@ fun <T> executeWithProject(project: File,
     
     // cleanup overridden property values to the state that they were before.
     propertyOverrides.forEach {
-        System.setProperty(it.first, it.second)
+
+        // if a property wasn't set before the value is "null"
+        // setting null as a value for a System property will result in a NPE
+        if(it.second != null) {
+            System.setProperty(it.first, it.second!!)
+        }
     }
 
     return res

--- a/project-loader/src/main/kotlin/Loader.kt
+++ b/project-loader/src/main/kotlin/Loader.kt
@@ -128,6 +128,8 @@ fun <T> executeWithProject(project: File,
         // setting null as a value for a System property will result in a NPE
         if(it.second != null) {
             System.setProperty(it.first, it.second!!)
+        } else {
+            System.clearProperty(it.first)
         }
     }
 

--- a/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
@@ -14,6 +14,7 @@ open class ModelCheckPluginExtensions: BasePluginExtensions() {
     var modules: List<String> = emptyList()
     var warningAsError = false
     var errorNoFail = false
+    var junitFile: File? = null
 }
 
 open class ModelcheckMpsProjectPlugin : Plugin<Project> {
@@ -47,6 +48,10 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
 
                 if (extension.errorNoFail) {
                     args.add("--error-no-fail")
+                }
+
+                if (extension.junitFile != null) {
+                    args.add("--result-file=${extension.junitFile!!.absolutePath}")
                 }
 
                 val resolveMps = tasks.create("resolveMpsForModelcheck", Copy::class.java) {


### PR DESCRIPTION
The model check plugin can not report its results as a JUnit xml file
which seems the defacto standard for test reporting in CI. For each
model that is checked it will create a testcase entry and report if as
failed if any model checking error is reported in that model. If multiple
error are reported in the same model they will all get reported as a
failed assertion in that test case.

Reporting is controlled via the new `junitFile` configuration for the
plugin. If the configuration is present the grade plugin will report
into that file.

The classes representing a JUnit XML file were placed in the common
package of the project loader plugin for easier reuse if we want to 
report from other plugins results as a junit xml file. 

I also fixed an NPE in case a property wasn't defined before the plugin
would executed. In this case resetting the value to `null` would cause
an exception in `System.setProperty`. 