### PR TITLE
Bugfix: add missing "generate" target

### DIFF
--- a/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
@@ -71,6 +71,6 @@ open class BuildLanguages : RunAntScript() {
 
 open class TestLanguages : RunAntScript() {
     init {
-        targets = listOf("clean", "generate", "check")
+        targets = listOf("clean", "generate", "assemble", "check")
     }
 }

--- a/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
@@ -65,12 +65,12 @@ open class RunAntScript : DefaultTask() {
 
 open class BuildLanguages : RunAntScript() {
     init {
-        targets = listOf("clean", "assemble")
+        targets = listOf("clean", "generate", "assemble")
     }
 }
 
 open class TestLanguages : RunAntScript() {
     init {
-        targets = listOf("clean", "check")
+        targets = listOf("clean", "generate", "check")
     }
 }


### PR DESCRIPTION
I assumed that it was a dependency of "assemble" so I deleted it but it
was a mistake.