### PR TITLE
modelcheck: add max heap size property

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,9 @@ Parameters:
 * `junitFile` - allows storing the the results of the model check as a JUnit XML file. The file will  contain one
   Testcase for each model that was checked. If the model check reported an error for the model the testcase will fail
   and he message of the model checking error will be reported.
+* `maxHeap` - maximum heap size setting for the JVM that executes the modelchecker. This is useful to limit the heap usage
+  in scenarios like containerized build agents where the OS reported memory limit is not the maximum
+  to be consumed by the container. The value is a string understood by the JVM command line argument `-Xmx` e.g. `3G` or `512M
   
 ### Additional Plugins 
 

--- a/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
@@ -15,6 +15,7 @@ open class ModelCheckPluginExtensions: BasePluginExtensions() {
     var warningAsError = false
     var errorNoFail = false
     var junitFile: File? = null
+    var maxHeap: String? = null
 }
 
 open class ModelcheckMpsProjectPlugin : Plugin<Project> {
@@ -63,6 +64,9 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
                     args(args)
                     group = "test"
                     description = "Check models in the project"
+                    if (extension.maxHeap != null) {
+                        maxHeapSize = extension.maxHeap!!
+                    }
                     classpath(fileTree(File(mpsLocation, "/lib")).include("**/*.jar"))
                     // http support doesn't follow the MPS convention to with a lib folder and we need it to print the
                     // node url to the console.


### PR DESCRIPTION
In some scenarios the OS reported memory limit isn't the same as the one
applied to individual processes, e.g. when running inside a container.
To prevent the process from being killed setting the max heap value is
required.