### PR TITLE
Modelcheck bugfixes

### DIFF
--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -16,6 +16,7 @@ import jetbrains.mps.progress.EmptyProgressMonitor
 import jetbrains.mps.project.Project
 import jetbrains.mps.project.validation.StructureChecker
 import jetbrains.mps.smodel.SModelStereotype
+import jetbrains.mps.typesystemEngine.checker.NonTypesystemChecker
 import jetbrains.mps.typesystemEngine.checker.TypesystemChecker
 import jetbrains.mps.util.CollectConsumer
 import org.apache.log4j.Logger
@@ -107,7 +108,6 @@ fun writeJunitXml(models: Iterable<SModel>,
                     is IssueKindReportItem.PathObject.NodePathObject -> {
                         val node = path.resolve(project.repository)
                         node.model!!
-
                     }
                     else -> fail("unexpected item type")
                 }
@@ -157,11 +157,12 @@ fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
     // see ModelCheckerSettings.getSpecificCheckers for details
     // we do not call into that class because we don't want to load the settings from the user
     val checkers = listOf(TypesystemChecker(),
+            NonTypesystemChecker(),
             ConstraintsChecker(null),
             RefScopeChecker(),
             TargetConceptChecker(),
-            UsedLanguagesChecker(),
             StructureChecker(),
+            UsedLanguagesChecker(),
             ModelPropertiesChecker(),
             UnresolvedReferencesChecker(project),
             ModuleChecker())

--- a/project-loader/src/main/kotlin/Args.kt
+++ b/project-loader/src/main/kotlin/Args.kt
@@ -23,7 +23,7 @@ private fun toPlugin(str: String) = splitAndCreate(str, ::Plugin)
 open class Args(parser: ArgParser) {
 
     val plugins by parser.adding("--plugin",
-            help = "plugin to to load. The format is --plugin=<path>::<id>")
+            help = "plugin to to load. The format is --plugin=<id>::<path>")
     { toPlugin(this) }
 
     val macros by parser.adding("--macro",

--- a/project-loader/src/main/kotlin/JUnit.kt
+++ b/project-loader/src/main/kotlin/JUnit.kt
@@ -56,7 +56,7 @@ data class Testcase(
         val systemErrors: List<SystemErr> = emptyList()
         )
 
-
+@JacksonXmlRootElement(localName = "testsuite")
 data class Testsuite(@field:JacksonXmlProperty(isAttribute = true)
                      val name: String,
                      @field:JacksonXmlProperty(isAttribute = true)

--- a/project-loader/src/main/kotlin/Loader.kt
+++ b/project-loader/src/main/kotlin/Loader.kt
@@ -110,7 +110,9 @@ fun <T> executeWithProject(project: File,
     ideaEnvironment.flushAllEvents()
 
     val pathMacros = PathMacros.getInstance()
-    macros.forEach { pathMacros.setMacro(it.name, it.value) }
+    // macros should not contain any backslashes from Windows-specific paths
+    // otherwise this might lead to exceptions in MPS (e.g. when loading libraries from paths with macros)
+    macros.forEach { pathMacros.setMacro(it.name, it.value.replace(File.separatorChar, '/')) }
 
     logger.info("opening project: ${project.absolutePath}")
     val ideaProject = ideaEnvironment.openProject(project)

--- a/src/main/kotlin/de/itemis/mps/gradle/generate/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/generate/Plugin.kt
@@ -94,7 +94,9 @@ open class GenerateMpsProjectPlugin : Plugin<Project> {
                     group = "build"
                     description = "Generates models in the project"
                     classpath(fileTree(File(mpsLocation, "/lib")).include("**/*.jar"))
-                    classpath(fileTree(File(mpsLocation, "/plugins")).include("**/lib/**/*.jar"))
+                    // add only minimal number of plugins jars that are required by the generate code
+                    // (to avoid conflicts with plugin classloader if custom configured plugins are loaded)
+                    //classpath(fileTree(File(mpsLocation, "/plugins")).include("<plugin-folder>/**/*.jar"))
                     classpath(genConfig)
                     debug = extension.debug
                     main = "de.itemis.mps.gradle.generate.MainKt"

--- a/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
@@ -97,9 +97,11 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
                         maxHeapSize = extension.maxHeap!!
                     }
                     classpath(fileTree(File(mpsLocation, "/lib")).include("**/*.jar"))
-                    // http support runtime is not located in lib folder, as all other plugin jars,
-                    // we need it to print the node url to the console.
-                    classpath(fileTree(File(mpsLocation, "/plugins")).include("**/lib/**/*.jar", "mps-httpsupport/**/jetbrains.mps.ide.httpsupport.runtime.jar"))
+                    // add only minimal number of plugins jars that are required by the modelcheck code
+                    // (to avoid conflicts with plugin classloader if custom configured plugins are loaded)
+                    // mps-httpsupport: we need it to print the node url to the console.
+                    // mps-modelchecker: contains used UnresolvedReferencesChecker
+                    classpath(fileTree(File(mpsLocation, "/plugins")).include("mps-modelchecker/**/*.jar", "mps-httpsupport/**/*.jar"))
                     classpath(genConfig)
                     debug = extension.debug
                     main = "de.itemis.mps.gradle.modelcheck.MainKt"


### PR DESCRIPTION
I have identified several issues when invoking model check from Maven:
- macros should have no backslashes, as this cause problems when loading libraries (an exception is thrown saying path is not platform-independent) -> patching macro values in the Loader before passing them to MPS
- when configuring additional plugins required to satisfy mbeddr plugins dependencies, I ran into classloader issue where same class is loaded twice - by the app classloader and by the plugin classloader. Because of this plugins cannot be properly activated -> I have removed all jars added to the classpath from the plugins folder except for those directly required by the modelcheck. Although this part is actually configured in my Maven build, the same type of problem should come up in the gradle context as soon as someone would try to load additional plugins.
- `NonTypesystemChecker` was missing in the modelchek and hence all checking rules were not executed -> added it to the applied checkers list.
- the resulting JUnit XML contained testcase for all models in the project, not considering configured model/modules scope for checking -> refactored JUnit XML writer accordingly
- currently we write single `<testsuite>` for all checking results, but put it into `<testsuites>` root. There is no need for this extra root, as JUnit XML can also contain single <testsuite> root -> refactored JUnit XML writer accordingly
