### PR TITLE
added SuppressErrorsChecker to have same checker behaviour as in MPS

### DIFF
--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -162,7 +162,8 @@ fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
             UsedLanguagesChecker(),
             ModelPropertiesChecker(),
             UnresolvedReferencesChecker(project),
-            ModuleChecker())
+            ModuleChecker(),
+            SuppressErrorsChecker())
 
 
     // We don't use ModelCheckerIssueFinder because it has strange dependency on the ModelCheckerSettings which we


### PR DESCRIPTION
Suppressed errors aren't reported in MPS by default, however the modelcheck plugin reports them as errors. To avoid this additional SuppressErrorsChecker has to be added to the checkers list.