### PR TITLE
Feature/junit output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,14 @@ Parameters:
 * `debug` - optionally allows to start the JVM that is used to load MPS project with a debugger. Setting it to `true` will cause
   the started JVM to suspend until a debugger is attached. Useful for debugging classloading problems or exceptions during
   the build.
-* `junitFile` - allows storing the the results of the model check as a JUnit XML file. The file will  contain one
-  Testcase for each model that was checked. If the model check reported an error for the model the testcase will fail
-  and he message of the model checking error will be reported.
+* `junitFile` - allows storing the the results of the model check as a JUnit XML file. By default, the file will contain one
+  testcase for each model that was checked (s. `junitFormat`).
+* `junitFormat` - allows to change the format of the JUnit XML file, how the model checking errors will be reported. Possible options:
+  * `model` (default) - generates one testcase for each model that was checked. If the model check reported any error for the model, 
+    the testcase will fail and the message of the model checking error will be reported. 
+  * `message` - generates one testcase for each model check error. For uniqueness reasons, the name of the testcase will reflect the specific
+    model check error and the name of the testclass will be constructed from the checked node ID and its containing root node. 
+    Full error message and the node URL will be reported in the testcase failure. Checked models will be mapped to testsuites with this option.     
 * `maxHeap` - maximum heap size setting for the JVM that executes the modelchecker. This is useful to limit the heap usage
   in scenarios like containerized build agents where the OS reported memory limit is not the maximum
   to be consumed by the container. The value is a string understood by the JVM command line argument `-Xmx` e.g. `3G` or `512M

--- a/execute-generators/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/execute-generators/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.0
+com.fasterxml.jackson.core:jackson-core:2.11.0
+com.fasterxml.jackson.core:jackson-databind:2.11.0
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
+com.fasterxml.woodstox:woodstox-core:6.2.0
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1

--- a/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.0
+com.fasterxml.jackson.core:jackson-core:2.11.0
+com.fasterxml.jackson.core:jackson-databind:2.11.0
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
+com.fasterxml.woodstox:woodstox-core:6.2.0
 com.jetbrains:mps-core:2019.3.4
 com.jetbrains:mps-httpsupport-runtime:2019.3.4
 com.jetbrains:mps-modelchecker:2019.3.4

--- a/modelcheck/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.0
+com.fasterxml.jackson.core:jackson-core:2.11.0
+com.fasterxml.jackson.core:jackson-databind:2.11.0
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
+com.fasterxml.woodstox:woodstox-core:6.2.0
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1

--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.default
 import com.xenomachina.argparser.mainBody
-import de.itemis.mps.gradle.junit.*
+import de.itemis.mps.gradle.junit.Failure
+import de.itemis.mps.gradle.junit.Testcase
+import de.itemis.mps.gradle.junit.Testsuite
+import de.itemis.mps.gradle.junit.Testsuites
 import de.itemis.mps.gradle.project.loader.Args
 import de.itemis.mps.gradle.project.loader.executeWithProject
 import jetbrains.mps.checkers.*
@@ -22,9 +25,16 @@ import jetbrains.mps.util.CollectConsumer
 import org.apache.log4j.Logger
 import org.jetbrains.mps.openapi.model.SModel
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
 import kotlin.test.fail
 
 private val logger = Logger.getLogger("de.itemis.mps.gradle.generate")
+
+enum class ReportFormat {
+    ONE_TEST_PER_MODEL,
+    ONE_TEST_PER_FAILED_MESSAGE
+}
 
 class ModelCheckArgs(parser: ArgParser) : Args(parser) {
     val models by parser.adding("--model",
@@ -34,6 +44,13 @@ class ModelCheckArgs(parser: ArgParser) : Args(parser) {
     val warningAsError by parser.flagging("--warning-as-error", help = "treat model checker warning as errors")
     val dontFailOnError by parser.flagging("--error-no-fail", help = "report errors but don't fail the build")
     val xmlFile by parser.storing("--result-file", help = "stores the result as an JUnit xml file").default<String?>(null)
+    val xmlReportFormat by parser.storing("--result-format", help = "reporting format for the JUnit file") {
+        when (this) {
+            "model" -> ReportFormat.ONE_TEST_PER_MODEL
+            "message" -> ReportFormat.ONE_TEST_PER_FAILED_MESSAGE
+            else -> fail("unsupported format")
+        }
+    }
 }
 
 fun printInfo(msg: String) {
@@ -46,6 +63,11 @@ fun printWarn(msg: String) {
 
 fun printError(msg: String) {
     logger.error(msg)
+}
+
+fun getCurrentTimeStamp(): String {
+    val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+    return df.format(Date())
 }
 
 fun printResult(item: IssueKindReportItem, project: Project, args: ModelCheckArgs) {
@@ -91,6 +113,7 @@ fun writeJunitXml(models: Iterable<SModel>,
                   results: Iterable<IssueKindReportItem>,
                   project: Project,
                   warnAsErrors: Boolean,
+                  format: ReportFormat,
                   file: File) {
 
     val allErrors = results.filter {
@@ -113,40 +136,99 @@ fun writeJunitXml(models: Iterable<SModel>,
                 }
             }
 
-    val testcases = models.map {
-        val errors = errorsPerModel.getOrDefault(it, emptyList())
+    val xmlMapper = XmlMapper()
 
-        fun reportItemToContent(item: IssueKindReportItem): Failure {
+    when (format) {
+        ReportFormat.ONE_TEST_PER_MODEL -> {
+            val testcases = oneTestCasePerModel(models, errorsPerModel, project)
+            val testsuite = Testsuite(name = "model checking",
+                    failures = allErrors.size,
+                    testcases = testcases,
+                    tests = models.count(),
+                    timestamp = getCurrentTimeStamp())
+            xmlMapper.writeValue(file, testsuite)
+        }
+
+        ReportFormat.ONE_TEST_PER_FAILED_MESSAGE -> {
+            val testsuits = models.mapIndexed { i: Int, mdl: SModel ->
+                val errorsInModel = errorsPerModel[mdl] ?: emptyList()
+                Testsuite(name = mdl.name.simpleName,
+                        pkg = mdl.name.namespace,
+                        failures = errorsInModel.size,
+                        id = i,
+                        tests = errorsInModel.size,
+                        timestamp = getCurrentTimeStamp(),
+                        testcases = errorsInModel.map { item -> oneTestCasePerMessage(item, mdl, project) })
+            }
+            xmlMapper.writeValue(file, Testsuites(testsuits))
+        }
+    }
+
+
+}
+
+private fun oneTestCasePerMessage(item: IssueKindReportItem, model: SModel, project: Project): Testcase {
+    return when (val path = IssueKindReportItem.PATH_OBJECT.get(item)) {
+        is IssueKindReportItem.PathObject.ModelPathObject -> {
+            val name = "${model.name.longName}#${item.issueKind.checker.name}"
+            val message = "${item.message} [${model.name.longName}]"
+            Testcase(
+                    name = name,
+                    classname = name,
+                    failure = Failure(message = message, type = item.issueKind.checker.name),
+                    time = 0
+            )
+        }
+        is IssueKindReportItem.PathObject.NodePathObject -> {
+            val node = path.resolve(project.repository)
+            val url = HttpSupportUtil.getURL(node)
+            val message = "${item.message} [$url]"
+            val name = "${node.nodeId}#${item.issueKind.checker.name}"
+            Testcase(
+                    name = name,
+                    classname = name,
+                    failure = Failure(message = message, type = item.issueKind.checker.name),
+                    time = 0
+            )
+        }
+        else -> fail("unexpected issue kind")
+    }
+}
+
+
+private fun oneTestCasePerModel(models: Iterable<SModel>, errorsPerModel: Map<SModel, List<IssueKindReportItem>>, project: Project): List<Testcase> {
+    return models.map {
+        val errors = errorsPerModel.getOrDefault(it, emptyList())
+        fun reportItemToContent(s: Failure, item: IssueKindReportItem): Failure {
             return when (val path = IssueKindReportItem.PATH_OBJECT.get(item)) {
                 is IssueKindReportItem.PathObject.ModelPathObject -> {
                     val model = path.resolve(project.repository)!!
                     val message = "${item.message} [${model.name.longName}]"
-                    Failure(message = message, content = message)
+                    Failure(
+                            message = "${s.message}\n $message",
+                            type = s.type
+                    )
                 }
                 is IssueKindReportItem.PathObject.NodePathObject -> {
                     val node = path.resolve(project.repository)
                     val url = HttpSupportUtil.getURL(node)
                     val message = "${item.message} [$url]"
-                    Failure(message = message, content = message)
+                    Failure(
+                            message = "${s.message}\n $message",
+                            type = s.type
+                    )
                 }
                 else -> fail("unexpected issue kind")
             }
         }
 
-        Testcase(name = it.name.simpleName,
+        Testcase(
+                name = it.name.simpleName,
                 classname = it.name.longName,
-                failures = errors.map(::reportItemToContent))
+                failure = errors.fold(Failure(message = "",  type = "model checking"), ::reportItemToContent),
+                time = 0
+        )
     }
-
-    val testsuite = Testsuite(name = "model checking",
-            failures = allErrors.size,
-            testcases = testcases,
-            id = 1,
-            tests = models.count())
-
-
-    val xmlMapper = XmlMapper()
-    xmlMapper.writeValue(file, testsuite)
 }
 
 fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
@@ -176,7 +258,7 @@ fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
     project.modelAccess.runReadAction {
         if (args.models.isNotEmpty()) {
             itemsToCheck.models.addAll(project.projectModulesWithGenerators
-                    .flatMap { it.models.filter { !SModelStereotype.isDescriptorModel(it) && !SModelStereotype.isStubModel(it) } }
+                    .flatMap { module -> module.models.filter { !SModelStereotype.isDescriptorModel(it) && !SModelStereotype.isStubModel(it) } }
                     .filter { m -> args.models.any { it.toRegex().matches(m.name.longName) } })
         }
         if (args.modules.isNotEmpty()) {
@@ -192,20 +274,18 @@ fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
         errorCollector.result.map { printResult(it, project, args) }
 
         if (args.xmlFile != null) {
-            val allCheckedModels = itemsToCheck.modules.flatMap {
-                it.models.filter { !SModelStereotype.isDescriptorModel(it) }
+            val allCheckedModels = itemsToCheck.modules.flatMap { module ->
+                module.models.filter { !SModelStereotype.isDescriptorModel(it) }
             }.union(itemsToCheck.models)
-            writeJunitXml(allCheckedModels, errorCollector.result, project, args.warningAsError, File(args.xmlFile!!))
+            writeJunitXml(allCheckedModels, errorCollector.result, project, args.warningAsError, args.xmlReportFormat, File(args.xmlFile!!))
         }
     }
 
-    val hasErrors = if (args.warningAsError) {
+    return if (args.warningAsError) {
         errorCollector.result.any { it.severity == MessageStatus.WARNING }
     } else {
         errorCollector.result.any { it.severity == MessageStatus.ERROR }
     }
-
-    return hasErrors
 }
 
 fun main(args: Array<String>) = mainBody {
@@ -225,4 +305,5 @@ fun main(args: Array<String>) = mainBody {
     }
 
     System.exit(0)
+
 }

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
     compileOnly("com.jetbrains:mps-openapi:$mpsVersion")
     compileOnly("com.jetbrains:platform-api:$mpsVersion")
     compileOnly("com.jetbrains:util:$mpsVersion")
+    testImplementation("junit:junit:4.12")
+    testImplementation("org.xmlunit:xmlunit-core:2.6.+")
 }
 
 tasks.withType<KotlinCompile> {

--- a/project-loader/gradle/dependency-locks/compileClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.0
+com.fasterxml.jackson.core:jackson-core:2.11.0
+com.fasterxml.jackson.core:jackson-databind:2.11.0
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
+com.fasterxml.woodstox:woodstox-core:6.2.0
 com.jetbrains:mps-core:2019.3.4
 com.jetbrains:mps-environment:2019.3.4
 com.jetbrains:mps-openapi:2019.3.4

--- a/project-loader/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.0
+com.fasterxml.jackson.core:jackson-core:2.11.0
+com.fasterxml.jackson.core:jackson-databind:2.11.0
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
+com.fasterxml.woodstox:woodstox-core:6.2.0
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1

--- a/project-loader/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,19 +1,22 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.0
+com.fasterxml.jackson.core:jackson-core:2.11.0
+com.fasterxml.jackson.core:jackson-databind:2.11.0
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
+com.fasterxml.woodstox:woodstox-core:6.2.0
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
+junit:junit:4.12
 org.codehaus.woodstox:stax2-api:4.2
+org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib:1.3.11
 org.jetbrains:annotations:13.0
+org.xmlunit:xmlunit-core:2.6.4

--- a/project-loader/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,19 +1,22 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.0
+com.fasterxml.jackson.core:jackson-core:2.11.0
+com.fasterxml.jackson.core:jackson-databind:2.11.0
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
+com.fasterxml.woodstox:woodstox-core:6.2.0
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
+junit:junit:4.12
 org.codehaus.woodstox:stax2-api:4.2
+org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib:1.3.11
 org.jetbrains:annotations:13.0
+org.xmlunit:xmlunit-core:2.6.4

--- a/project-loader/src/main/kotlin/JUnit.kt
+++ b/project-loader/src/main/kotlin/JUnit.kt
@@ -3,22 +3,39 @@ package de.itemis.mps.gradle.junit
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.dataformat.xml.annotation.*
 
-data class Skipped(@JacksonXmlProperty(isAttribute = true)
-                   val message: String,
-                   @field:JacksonXmlText() val content: String)
+data class Skipped(@field:JacksonXmlText() val content: String)
 
-data class Error(@field:JacksonXmlProperty(isAttribute = true)
-                 val message: String,
-                 @field:JacksonXmlProperty(isAttribute = true)
-                 val type: String? = null,
-                 @field:JacksonXmlText() val content: String)
+/**
+ * Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace
+ */
+data class Error(
+        /**
+         * The error message. e.g., if a java exception is thrown, the return value of getMessage()
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val message: String,
+        /**
+         * The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val type: String,
+        @field:JacksonXmlText() val content: String? = null)
 
-
-data class Failure(@field:JacksonXmlProperty(isAttribute = true)
-                   val message: String,
-                   @field:JacksonXmlProperty(isAttribute = true)
-                   val type: String? = null,
-                   @field:JacksonXmlText() val content: String)
+/**
+ * Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace
+ */
+data class Failure(
+        /**
+         * The message specified in the assert
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val message: String,
+        /**
+         * The type of the assert.
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val type: String,
+        @field:JacksonXmlText() val content: String? = null)
 
 data class SystemOut(@field:JacksonXmlText()
                      val content: String)
@@ -28,72 +45,119 @@ data class SystemErr(@field:JacksonXmlText()
 
 
 data class Testcase(
+        /**
+         * Name of the test method
+         */
         @field:JacksonXmlProperty(isAttribute = true)
         val name: String,
+        /**
+         * Full class name for the class the test method is in.
+         */
         @field:JacksonXmlProperty(isAttribute = true)
         val classname: String,
+        /**
+         * Time taken (in seconds) to execute the test
+         */
         @field:JacksonXmlProperty(isAttribute = true)
-        val assertions: Int? = null,
-        @field:JacksonXmlProperty(isAttribute = true)
-        val status: String? = null,
-        @field:JacksonXmlProperty(isAttribute = true)
-        val time: String? = null,
+        val time: Int,
         @field:JacksonXmlElementWrapper(useWrapping = false)
         @field:JacksonXmlProperty(localName = "skipped")
         @field:JsonInclude(JsonInclude.Include.NON_NULL)
         val skipped: Skipped? = null,
         @field:JacksonXmlElementWrapper(useWrapping = false)
         @field:JacksonXmlProperty(localName = "error")
-        val errors: List<Error> = emptyList(),
+        @field:JsonInclude(JsonInclude.Include.NON_NULL)
+        val error: Error? = null,
         @field:JacksonXmlElementWrapper(useWrapping = false)
         @field:JacksonXmlProperty(localName = "failure")
-        val failures: List<Failure> = emptyList(),
-        @field:JacksonXmlElementWrapper(useWrapping = false)
-        @field:JacksonXmlProperty(localName = "system-out")
-        val systemOuts: List<SystemOut> = emptyList(),
-        @field:JacksonXmlElementWrapper(useWrapping = false)
-        @field:JacksonXmlProperty(localName = "system-err")
-        val systemErrors: List<SystemErr> = emptyList()
-        )
-
-@JacksonXmlRootElement(localName = "testsuite")
-data class Testsuite(@field:JacksonXmlProperty(isAttribute = true)
-                     val name: String,
-                     @field:JacksonXmlProperty(isAttribute = true)
-                     val tests: Int,
-                     @field:JacksonXmlProperty(isAttribute = true)
-                     val disabled: Int? = null,
-                     @field:JacksonXmlProperty(isAttribute = true)
-                     val errors: Int? = null,
-                     @field:JacksonXmlProperty(isAttribute = true)
-                     val failures: Int? = null,
-                     @field:JacksonXmlProperty(isAttribute = true)
-                     val id: Int,
-                     @field:JacksonXmlProperty(localName = "package", isAttribute = true)
-                     val pkg: String? = null,
-                     @field:JacksonXmlProperty(isAttribute = true)
-                     val skipped: Int? = null,
-                     @field:JacksonXmlProperty(isAttribute = true)
-                     val time: Int? = null,
-                     @field:JacksonXmlProperty(isAttribute = true)
-                     val timestamp: String? = null,
-                     @field:JacksonXmlElementWrapper(useWrapping = false)
-                     @field:JacksonXmlProperty(localName = "testcase")
-                     val testcases: List<Testcase>
+        @field:JsonInclude(JsonInclude.Include.NON_NULL)
+        val failure: Failure? = null
 )
 
+@JacksonXmlRootElement(localName = "testsuite")
+data class Testsuite(
+        /**
+         * Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val name: String,
+        /**
+         * The total number of tests in the suite
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val tests: Int,
+        /**
+         * The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val errors: Int = 0,
+        /**
+         * The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val failures: Int = 0,
+        /**
+         * Only required if contained in a testsuites list
+         * Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val id: Int? = null,
+        /**
+         * Derived from testsuite/@name in the non-aggregated documents
+         */
+        @field:JacksonXmlProperty(localName = "package", isAttribute = true)
+        val pkg: String? = null,
+        /**
+         * The total number of ignored or skipped tests in the suite.
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val skipped: Int? = null,
+        /**
+         * Time taken (in seconds) to execute the tests in the suite
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val time: Int = 0,
+        /**
+         * when the test was executed. Timezone may not be specified.
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val timestamp: String,
+        /**
+         * Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.
+         */
+        @field:JacksonXmlProperty(isAttribute = true)
+        val hostname: String = "localhost",
+        /**
+         * Properties (e.g., environment settings) set during test execution
+         */
+        @field:JacksonXmlElementWrapper(useWrapping = true)
+        @field:JacksonXmlProperty(localName = "properties")
+        val properties: List<Property> = emptyList(),
+        @field:JacksonXmlElementWrapper(useWrapping = false)
+        @field:JacksonXmlProperty(localName = "testcase")
+        val testcases: List<Testcase>,
+        /**
+         * Data that was written to standard out while the test was executed
+         */
+        @field:JacksonXmlElementWrapper(useWrapping = false)
+        @field:JacksonXmlProperty(localName = "system-out")
+        val systemOut: SystemOut = SystemOut(""),
+        /**
+         * Data that was written to standard error while the test was executed
+         */
+        @field:JacksonXmlElementWrapper(useWrapping = false)
+        @field:JacksonXmlProperty(localName = "system-err")
+        val systemError: SystemErr = SystemErr("")
+)
+
+data class Property(
+        @field:JacksonXmlProperty(isAttribute = true)
+        val name: String,
+        @field:JacksonXmlProperty(isAttribute = true)
+        val value: String)
+
 @JacksonXmlRootElement(localName = "testsuites")
-data class Testsuites(@field:JacksonXmlProperty(isAttribute = true)
-                      val disabled: Int = 0,
-                      @field:JacksonXmlProperty(isAttribute = true)
-                      val errors: Int = 0,
-                      @field:JacksonXmlProperty(isAttribute = true)
-                      val failures: Int = 0,
-                      @field:JacksonXmlProperty(isAttribute = true)
-                      val name: String,
-                      @field:JacksonXmlProperty(isAttribute = true)
-                      val tests: Int,
-                      @field:JacksonXmlElementWrapper(useWrapping = false,localName = "testsuite")
+data class Testsuites(@field:JacksonXmlElementWrapper(useWrapping = false, localName = "testsuite")
                       @field:JacksonXmlProperty(localName = "testsuite")
                       val testsuites: List<Testsuite>
 )

--- a/project-loader/src/test/kotlin/JUnitXml.kt
+++ b/project-loader/src/test/kotlin/JUnitXml.kt
@@ -1,0 +1,248 @@
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import de.itemis.mps.gradle.junit.*
+import org.junit.Assert
+import org.junit.Test
+import org.xmlunit.validation.Languages
+import org.xmlunit.validation.Validator
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.net.InetAddress
+import java.net.URL
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.xml.transform.stream.StreamSource
+
+
+class JUnitXmlTest {
+
+    private fun String.loadResource(): URL? {
+        return this@JUnitXmlTest::class.java.getResource(this)
+    }
+
+    fun getCurrentTimeStamp(): String {
+        val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+        return df.format(Date())
+    }
+
+    @Test
+    fun `minimum test suite is valid`() {
+        validateWithJunitSchema(Testsuite(
+                name = "my tests",
+                testcases = emptyList(),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut("")
+        ))
+    }
+
+    @Test
+    fun `everything test suite is valid`() {
+        validateWithJunitSchema(Testsuite(
+                name = "my tests",
+                testcases = emptyList(),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                hostname = "my host",
+                failures = 42,
+                errors = 12,
+                time = 4212,
+                skipped = 32
+        ))
+    }
+
+    @Test
+    fun `test suite with one simple test is valid`() {
+
+        val test = Testcase(name = "my fancy test", classname = "my class name", time = 0)
+        validateWithJunitSchema(Testsuite(
+                name = "my tests",
+                testcases = listOf(test),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                hostname = "my host",
+                failures = 42,
+                errors = 12,
+                time = 4212,
+                skipped = 32
+        ))
+    }
+
+    @Test
+    fun `test suite with one complex test with error is valid`() {
+
+        val test = Testcase(
+                name = "my fancy test",
+                classname = "my class name",
+                time = 0,
+                error = de.itemis.mps.gradle.junit.Error(message = "my message", type = "")
+        )
+        validateWithJunitSchema(Testsuite(
+                name = "my tests",
+                testcases = listOf(test),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                hostname = "my host",
+                failures = 42,
+                errors = 12,
+                time = 4212,
+                skipped = 32
+        ))
+    }
+
+    @Test
+    fun `test suite with one complex test with error and content is valid`() {
+
+        val test = Testcase(
+                name = "my fancy test",
+                classname = "my class name",
+                time = 0,
+                error = de.itemis.mps.gradle.junit.Error(message = "my message", type = "", content = "something")
+        )
+        validateWithJunitSchema(Testsuite(
+                name = "my tests",
+                testcases = listOf(test),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                hostname = "my host",
+                failures = 42,
+                errors = 12,
+                time = 4212,
+                skipped = 32
+        ))
+    }
+
+    @Test
+    fun `test suite with one complex test with failure is valid`() {
+
+        val test = Testcase(
+                name = "my fancy test",
+                classname = "my class name",
+                time = 0,
+                failure = de.itemis.mps.gradle.junit.Failure(message = "my message", type = "")
+        )
+        validateWithJunitSchema(Testsuite(
+                name = "my tests",
+                testcases = listOf(test),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                hostname = "my host",
+                failures = 42,
+                errors = 12,
+                time = 4212,
+                skipped = 32
+        ))
+    }
+
+    @Test
+    fun `test suite with one complex test with failure and content is valid`() {
+
+        val test = Testcase(
+                name = "my fancy test",
+                classname = "my class name",
+                time = 0,
+                failure = de.itemis.mps.gradle.junit.Failure(message = "my message", type = "", content = "something")
+        )
+        validateWithJunitSchema(Testsuite(
+                name = "my tests",
+                testcases = listOf(test),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                hostname = "my host",
+                failures = 42,
+                errors = 12,
+                time = 4212,
+                skipped = 32
+        ))
+    }
+
+    @Test
+    fun `test suite with one complex test with skipped is valid`() {
+
+        val test = Testcase(
+                name = "my fancy test",
+                classname = "my class name",
+                time = 0,
+                skipped = de.itemis.mps.gradle.junit.Skipped(content = "something")
+        )
+        validateWithJunitSchema(Testsuite(
+                name = "my tests",
+                testcases = listOf(test),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                hostname = "my host",
+                failures = 42,
+                errors = 12,
+                time = 4212,
+                skipped = 32
+        ))
+    }
+
+    @Test
+    fun `test suits with one test suite is valid`() {
+        val testsuite = Testsuite(
+                name = "my tests",
+                testcases = emptyList(),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                id = 0,
+                pkg = "something"
+        )
+        validateWithJunitSchema(Testsuites(listOf(testsuite)))
+    }
+
+    @Test
+    fun `test suits with test suites is valid`() {
+        val testsuite = Testsuite(
+                name = "my tests",
+                testcases = emptyList(),
+                tests = 0,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                id = 0,
+                pkg = "something"
+        )
+        val testsuite2 = Testsuite(
+                name = "my tests 2",
+                testcases = emptyList(),
+                tests = 34,
+                timestamp = getCurrentTimeStamp(),
+                systemError = SystemErr(""),
+                systemOut = SystemOut(""),
+                id = 1,
+                pkg = "something"
+        )
+        validateWithJunitSchema(Testsuites(listOf(testsuite, testsuite2)))
+    }
+
+    private fun validateWithJunitSchema(it: Any) {
+        val v = Validator.forLanguage(Languages.W3C_XML_SCHEMA_NS_URI)
+        v.setSchemaSource(StreamSource("junit.xsd".loadResource()!!.openStream(), "JUni.xsd"))
+        val xmlMapper = XmlMapper()
+        val outputStream = ByteArrayOutputStream()
+        xmlMapper.writeValue(outputStream, it)
+        val inputStream = ByteArrayInputStream(outputStream.toByteArray())
+        val result = v.validateInstance(StreamSource(inputStream))
+        Assert.assertTrue(result.problems.joinToString { it.message }, result.isValid)
+    }
+
+
+}

--- a/project-loader/src/test/resources/junit.xsd
+++ b/project-loader/src/test/resources/junit.xsd
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+            Copyright © 2011, Windy Road Technology Pty. Limited
+            The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
+            Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+    </xs:annotation>
+    <xs:element name="testsuite" type="testsuite"/>
+    <xs:simpleType name="ISO8601_DATETIME_PATTERN">
+        <xs:restriction base="xs:dateTime">
+            <xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="testsuites">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:complexContent>
+                            <xs:extension base="testsuite">
+                                <xs:attribute name="package" type="xs:token" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="id" type="xs:int" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:extension>
+                        </xs:complexContent>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="testsuite">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Contains the results of exexuting a testsuite</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="properties">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="name" use="required">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:token">
+                                            <xs:minLength value="1"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                                <xs:attribute name="value" type="xs:string" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:choice minOccurs="0">
+                        <xs:element name="skipped" />
+                        <xs:element name="error" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="pre-string">
+                                        <xs:attribute name="message" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="type" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="failure">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="pre-string">
+                                        <xs:attribute name="message" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="type" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                    <xs:attribute name="name" type="xs:token" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="classname" type="xs:token" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="time" type="xs:decimal" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="system-out">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="pre-string">
+                        <xs:whiteSpace value="preserve"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="system-err">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="pre-string">
+                        <xs:whiteSpace value="preserve"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="hostname" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="tests" type="xs:int" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="failures" type="xs:int" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="errors" type="xs:int" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="skipped" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">The total number of ignored or skipped tests in the suite.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="time" type="xs:decimal" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:simpleType name="pre-string">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="preserve"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
@@ -19,6 +19,7 @@ open class ModelCheckPluginExtensions: BasePluginExtensions() {
     var warningAsError = false
     var errorNoFail = false
     var junitFile: File? = null
+    var junitFormat: String? = null
     var maxHeap: String? = null
 }
 
@@ -57,6 +58,10 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
 
                 if (extension.junitFile != null) {
                     args.add("--result-file=${extension.junitFile!!.absolutePath}")
+                }
+
+                if (extension.junitFormat != null) {
+                    args.add("--result-format=${extension.junitFormat}")
                 }
 
                 val resolveMps = tasks.create("resolveMpsForModelcheck", Copy::class.java) {


### PR DESCRIPTION
This PR adds support for creating JUnit XML file for model checker errors in a different format, generating testcase per each found model check error. This allows to recognize the total number of model checker errors in the checked models, see changes of that number if it increases or decreases with each commit and if needed, to mute individual errors on the build server.