### PR TITLE
No more empty failures on passing builds

### DIFF
--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -224,11 +224,13 @@ private fun oneTestCasePerModel(models: Iterable<SModel>, errorsPerModel: Map<SM
                 else -> fail("unexpected issue kind")
             }
         }
+        
+        val accumulatedFailure = errors.fold(Failure(message = "",  type = "model checking"), ::reportItemToContent)
 
         Testcase(
                 name = it.name.simpleName,
                 classname = it.name.longName,
-                failure = errors.fold(Failure(message = "",  type = "model checking"), ::reportItemToContent),
+                failure = if (errors.isEmpty()) null else accumulatedFailure,
                 time = 0
         )
     }


### PR DESCRIPTION
junitFormat=model was always generating failing junit xmls.

I couldn't test it yet though

# Before
<img width="974" alt="grafik" src="https://user-images.githubusercontent.com/569215/82234208-667aea00-9931-11ea-9c28-e10ac6854546.png">

# Expected Afterwards
<img width="695" alt="grafik" src="https://user-images.githubusercontent.com/569215/82234233-6e3a8e80-9931-11ea-9132-c425c24610a4.png">
