### PR TITLE
Migration to MPS 2020.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ val nexusUsername: String? by project
 val nexusPassword: String? by project
 
 val kotlinArgParserVersion by extra { "2.0.7" }
-val mpsVersion by extra { "2020.1.3" }
+val mpsVersion by extra { "2020.1.6" }
 
 
 version = if (!project.hasProperty("useSnapshot") &&

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ val nexusUsername: String? by project
 val nexusPassword: String? by project
 
 val kotlinArgParserVersion by extra { "2.0.7" }
-val mpsVersion by extra { "2019.3.4" }
+val mpsVersion by extra { "2020.1.3" }
 
 
 version = if (!project.hasProperty("useSnapshot") &&

--- a/execute-generators/gradle/dependency-locks/compileClasspath.lockfile
+++ b/execute-generators/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.jetbrains:mps-core:2019.3.4
-com.jetbrains:mps-messaging:2019.3.4
-com.jetbrains:mps-openapi:2019.3.4
-com.jetbrains:mps-tool:2019.3.4
-com.jetbrains:platform-api:2019.3.4
-com.jetbrains:platform-concurrency:2019.3.4
+com.jetbrains:mps-core:2020.1.3
+com.jetbrains:mps-messaging:2020.1.3
+com.jetbrains:mps-openapi:2020.1.3
+com.jetbrains:mps-tool:2020.1.3
+com.jetbrains:platform-api:2020.1.3
+com.jetbrains:platform-concurrency:2020.1.3
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11

--- a/execute-generators/gradle/dependency-locks/compileClasspath.lockfile
+++ b/execute-generators/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.jetbrains:mps-core:2020.1.3
-com.jetbrains:mps-messaging:2020.1.3
-com.jetbrains:mps-openapi:2020.1.3
-com.jetbrains:mps-tool:2020.1.3
-com.jetbrains:platform-api:2020.1.3
-com.jetbrains:platform-concurrency:2020.1.3
+com.jetbrains:mps-core:2020.1.6
+com.jetbrains:mps-messaging:2020.1.6
+com.jetbrains:mps-openapi:2020.1.6
+com.jetbrains:mps-tool:2020.1.6
+com.jetbrains:platform-api:2020.1.6
+com.jetbrains:platform-concurrency:2020.1.6
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11

--- a/execute-generators/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
+++ b/execute-generators/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.jetbrains:mps-core:2020.1.3
-com.jetbrains:mps-messaging:2020.1.3
-com.jetbrains:mps-openapi:2020.1.3
-com.jetbrains:mps-tool:2020.1.3
-com.jetbrains:platform-api:2020.1.3
-com.jetbrains:platform-concurrency:2020.1.3
+com.jetbrains:mps-core:2020.1.6
+com.jetbrains:mps-messaging:2020.1.6
+com.jetbrains:mps-openapi:2020.1.6
+com.jetbrains:mps-tool:2020.1.6
+com.jetbrains:platform-api:2020.1.6
+com.jetbrains:platform-concurrency:2020.1.6

--- a/execute-generators/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
+++ b/execute-generators/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.jetbrains:mps-core:2019.3.4
-com.jetbrains:mps-messaging:2019.3.4
-com.jetbrains:mps-openapi:2019.3.4
-com.jetbrains:mps-tool:2019.3.4
-com.jetbrains:platform-api:2019.3.4
-com.jetbrains:platform-concurrency:2019.3.4
+com.jetbrains:mps-core:2020.1.3
+com.jetbrains:mps-messaging:2020.1.3
+com.jetbrains:mps-openapi:2020.1.3
+com.jetbrains:mps-tool:2020.1.3
+com.jetbrains:platform-api:2020.1.3
+com.jetbrains:platform-concurrency:2020.1.3

--- a/execute-generators/gradle/dependency-locks/default.lockfile
+++ b/execute-generators/gradle/dependency-locks/default.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/execute-generators/gradle/dependency-locks/default.lockfile
+++ b/execute-generators/gradle/dependency-locks/default.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/execute-generators/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/execute-generators/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0
-com.fasterxml.jackson.core:jackson-core:2.11.0
-com.fasterxml.jackson.core:jackson-databind:2.11.0
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
-com.fasterxml.woodstox:woodstox-core:6.2.0
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/execute-generators/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/execute-generators/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/execute-generators/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/execute-generators/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/execute-generators/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/execute-generators/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/Helper.kt
+++ b/execute-generators/src/main/kotlin/de/itemis/mps/gradle/generate/Helper.kt
@@ -42,7 +42,7 @@ private class MsgHandler : IMessageHandler {
 
 }
 
-private fun createScript(proj: Project, models: List<org.jetbrains.mps.openapi.model.SModel>): IScript {
+private fun createScript(proj: Project, models: List<SModel>): IScript {
 
     val allUsedLanguagesAR: AsyncPromise<Set<SLanguage>> = AsyncPromise()
     val registry = LanguageRegistry.getInstance(proj.repository)
@@ -54,7 +54,8 @@ private fun createScript(proj: Project, models: List<org.jetbrains.mps.openapi.m
 
     val allUsedLanguages = allUsedLanguagesAR.get()
 
-    val scb = ScriptBuilder()
+    val facetRegistry = proj.getComponent(FacetRegistry::class.java)
+    val scb = ScriptBuilder (facetRegistry)
 
     when {
         allUsedLanguages == null -> logger.error("failed to retrieve used languages")
@@ -67,7 +68,6 @@ private fun createScript(proj: Project, models: List<org.jetbrains.mps.openapi.m
                     .map { it.name }
             )
 
-            val facetRegistry = proj.getComponent(FacetRegistry::class.java)
 
             scb.withFacetNames(allUsedLanguages
                     .flatMap { facetRegistry.getFacetsForLanguage(it.qualifiedName) }
@@ -83,7 +83,7 @@ private fun createScript(proj: Project, models: List<org.jetbrains.mps.openapi.m
     return scb.withFacetNames(DEFAULT_FACETS).withFinalTarget(ITarget.Name("jetbrains.mps.make.facets.Make.make")).toScript()
 }
 
-private fun makeModels(proj: Project, models: List<org.jetbrains.mps.openapi.model.SModel>): Boolean {
+private fun makeModels(proj: Project, models: List<SModel>): Boolean {
     val session = MakeSession(proj, MsgHandler(), true)
     val res = ModelsToResources(models).resources().toList()
     val makeService = BuildMakeService()

--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -48,6 +48,10 @@ dependencies {
     compileOnly("com.jetbrains:mps-modelchecker:$mpsVersion")
     compileOnly("com.jetbrains:mps-httpsupport-runtime:$mpsVersion")
     compileOnly("com.jetbrains:mps-project-check:$mpsVersion")
+    compileOnly("com.jetbrains:mps-platform:$mpsVersion")
+    compileOnly("com.jetbrains:platform-api:$mpsVersion")
+    compileOnly("com.jetbrains:extensions:$mpsVersion")
+    compileOnly("com.jetbrains:util:$mpsVersion")
     implementation(project(":project-loader"))
 }
 

--- a/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
@@ -7,11 +7,15 @@ com.fasterxml.jackson.core:jackson-databind:2.11.1
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
 com.fasterxml.woodstox:woodstox-core:6.2.1
+com.jetbrains:extensions:2020.1.3
 com.jetbrains:mps-core:2020.1.3
 com.jetbrains:mps-httpsupport-runtime:2020.1.3
 com.jetbrains:mps-modelchecker:2020.1.3
 com.jetbrains:mps-openapi:2020.1.3
+com.jetbrains:mps-platform:2020.1.3
 com.jetbrains:mps-project-check:2020.1.3
+com.jetbrains:platform-api:2020.1.3
+com.jetbrains:util:2020.1.3
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1

--- a/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,22 +1,22 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0
-com.fasterxml.jackson.core:jackson-core:2.11.0
-com.fasterxml.jackson.core:jackson-databind:2.11.0
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
-com.fasterxml.woodstox:woodstox-core:6.2.0
-com.jetbrains:mps-core:2019.3.4
-com.jetbrains:mps-httpsupport-runtime:2019.3.4
-com.jetbrains:mps-modelchecker:2019.3.4
-com.jetbrains:mps-openapi:2019.3.4
-com.jetbrains:mps-project-check:2019.3.4
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
+com.jetbrains:mps-core:2020.1.3
+com.jetbrains:mps-httpsupport-runtime:2020.1.3
+com.jetbrains:mps-modelchecker:2020.1.3
+com.jetbrains:mps-openapi:2020.1.3
+com.jetbrains:mps-project-check:2020.1.3
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,21 +1,22 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
-com.jetbrains:extensions:2020.1.3
-com.jetbrains:mps-core:2020.1.3
-com.jetbrains:mps-httpsupport-runtime:2020.1.3
-com.jetbrains:mps-modelchecker:2020.1.3
-com.jetbrains:mps-openapi:2020.1.3
-com.jetbrains:mps-platform:2020.1.3
-com.jetbrains:mps-project-check:2020.1.3
-com.jetbrains:platform-api:2020.1.3
-com.jetbrains:util:2020.1.3
+com.jetbrains:extensions:2020.1.6
+com.jetbrains:mps-core:2020.1.6
+com.jetbrains:mps-httpsupport-runtime:2020.1.6
+com.jetbrains:mps-modelchecker:2020.1.6
+com.jetbrains:mps-openapi:2020.1.6
+com.jetbrains:mps-platform:2020.1.6
+com.jetbrains:mps-project-check:2020.1.6
+com.jetbrains:platform-api:2020.1.6
+com.jetbrains:util:2020.1.6
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1

--- a/modelcheck/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
+++ b/modelcheck/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.jetbrains:extensions:2020.1.3
-com.jetbrains:mps-core:2020.1.3
-com.jetbrains:mps-httpsupport-runtime:2020.1.3
-com.jetbrains:mps-modelchecker:2020.1.3
-com.jetbrains:mps-openapi:2020.1.3
-com.jetbrains:mps-platform:2020.1.3
-com.jetbrains:mps-project-check:2020.1.3
-com.jetbrains:platform-api:2020.1.3
-com.jetbrains:util:2020.1.3
+com.jetbrains:extensions:2020.1.6
+com.jetbrains:mps-core:2020.1.6
+com.jetbrains:mps-httpsupport-runtime:2020.1.6
+com.jetbrains:mps-modelchecker:2020.1.6
+com.jetbrains:mps-openapi:2020.1.6
+com.jetbrains:mps-platform:2020.1.6
+com.jetbrains:mps-project-check:2020.1.6
+com.jetbrains:platform-api:2020.1.6
+com.jetbrains:util:2020.1.6

--- a/modelcheck/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
+++ b/modelcheck/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.jetbrains:mps-core:2019.3.4
-com.jetbrains:mps-httpsupport-runtime:2019.3.4
-com.jetbrains:mps-modelchecker:2019.3.4
-com.jetbrains:mps-openapi:2019.3.4
-com.jetbrains:mps-project-check:2019.3.4
+com.jetbrains:mps-core:2020.1.3
+com.jetbrains:mps-httpsupport-runtime:2020.1.3
+com.jetbrains:mps-modelchecker:2020.1.3
+com.jetbrains:mps-openapi:2020.1.3
+com.jetbrains:mps-project-check:2020.1.3

--- a/modelcheck/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
+++ b/modelcheck/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
@@ -1,8 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.jetbrains:extensions:2020.1.3
 com.jetbrains:mps-core:2020.1.3
 com.jetbrains:mps-httpsupport-runtime:2020.1.3
 com.jetbrains:mps-modelchecker:2020.1.3
 com.jetbrains:mps-openapi:2020.1.3
+com.jetbrains:mps-platform:2020.1.3
 com.jetbrains:mps-project-check:2020.1.3
+com.jetbrains:platform-api:2020.1.3
+com.jetbrains:util:2020.1.3

--- a/modelcheck/gradle/dependency-locks/default.lockfile
+++ b/modelcheck/gradle/dependency-locks/default.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/modelcheck/gradle/dependency-locks/default.lockfile
+++ b/modelcheck/gradle/dependency-locks/default.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/modelcheck/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/modelcheck/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/modelcheck/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/modelcheck/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/modelcheck/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0
-com.fasterxml.jackson.core:jackson-core:2.11.0
-com.fasterxml.jackson.core:jackson-databind:2.11.0
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
-com.fasterxml.woodstox:woodstox-core:6.2.0
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/modelcheck/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/modelcheck/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/modelcheck/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/modelcheck/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/modelcheck/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/modelcheck/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/modelcheck/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/modelcheck/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/modelcheck/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -1,6 +1,7 @@
 package de.itemis.mps.gradle.modelcheck
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.intellij.openapi.application.ApplicationManager
 import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.default
 import com.xenomachina.argparser.mainBody
@@ -13,6 +14,7 @@ import de.itemis.mps.gradle.project.loader.executeWithProject
 import jetbrains.mps.checkers.*
 import jetbrains.mps.errors.MessageStatus
 import jetbrains.mps.errors.item.IssueKindReportItem
+import jetbrains.mps.ide.MPSCoreComponents
 import jetbrains.mps.ide.httpsupport.runtime.base.HttpSupportUtil
 import jetbrains.mps.ide.modelchecker.platform.actions.UnresolvedReferencesChecker
 import jetbrains.mps.progress.EmptyProgressMonitor
@@ -243,16 +245,18 @@ private fun oneTestCasePerModel(models: Iterable<SModel>, errorsPerModel: Map<SM
 
 fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
 
+    val componentHost = ApplicationManager.getApplication().getComponent(MPSCoreComponents::class.java).platform
+
     // see ModelCheckerSettings.getSpecificCheckers for details
     // we do not call into that class because we don't want to load the settings from the user
     val checkers = listOf(TypesystemChecker(),
             NonTypesystemChecker(),
-            ConstraintsChecker(null),
+            ConstraintsChecker(componentHost),
             RefScopeChecker(),
-            TargetConceptChecker(),
+            TargetConceptChecker2(componentHost),
             StructureChecker(),
             UsedLanguagesChecker(),
-            ModelPropertiesChecker(),
+            ModelPropertiesChecker(componentHost),
             UnresolvedReferencesChecker(project),
             ModuleChecker(),
             SuppressErrorsChecker())

--- a/project-loader/gradle/dependency-locks/compileClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,23 +1,23 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0
-com.fasterxml.jackson.core:jackson-core:2.11.0
-com.fasterxml.jackson.core:jackson-databind:2.11.0
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
-com.fasterxml.woodstox:woodstox-core:6.2.0
-com.jetbrains:mps-core:2019.3.4
-com.jetbrains:mps-environment:2019.3.4
-com.jetbrains:mps-openapi:2019.3.4
-com.jetbrains:mps-platform:2019.3.4
-com.jetbrains:platform-api:2019.3.4
-com.jetbrains:util:2019.3.4
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
+com.jetbrains:mps-core:2020.1.3
+com.jetbrains:mps-environment:2020.1.3
+com.jetbrains:mps-openapi:2020.1.3
+com.jetbrains:mps-platform:2020.1.3
+com.jetbrains:platform-api:2020.1.3
+com.jetbrains:util:2020.1.3
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/project-loader/gradle/dependency-locks/compileClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,18 +1,19 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
-com.jetbrains:mps-core:2020.1.3
-com.jetbrains:mps-environment:2020.1.3
-com.jetbrains:mps-openapi:2020.1.3
-com.jetbrains:mps-platform:2020.1.3
-com.jetbrains:platform-api:2020.1.3
-com.jetbrains:util:2020.1.3
+com.jetbrains:mps-core:2020.1.6
+com.jetbrains:mps-environment:2020.1.6
+com.jetbrains:mps-openapi:2020.1.6
+com.jetbrains:mps-platform:2020.1.6
+com.jetbrains:platform-api:2020.1.6
+com.jetbrains:util:2020.1.6
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1

--- a/project-loader/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
+++ b/project-loader/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.jetbrains:mps-core:2019.3.4
-com.jetbrains:mps-environment:2019.3.4
-com.jetbrains:mps-openapi:2019.3.4
-com.jetbrains:mps-platform:2019.3.4
-com.jetbrains:platform-api:2019.3.4
-com.jetbrains:util:2019.3.4
+com.jetbrains:mps-core:2020.1.3
+com.jetbrains:mps-environment:2020.1.3
+com.jetbrains:mps-openapi:2020.1.3
+com.jetbrains:mps-platform:2020.1.3
+com.jetbrains:platform-api:2020.1.3
+com.jetbrains:util:2020.1.3

--- a/project-loader/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
+++ b/project-loader/gradle/dependency-locks/compileOnlyDependenciesMetadata.lockfile
@@ -1,9 +1,9 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.jetbrains:mps-core:2020.1.3
-com.jetbrains:mps-environment:2020.1.3
-com.jetbrains:mps-openapi:2020.1.3
-com.jetbrains:mps-platform:2020.1.3
-com.jetbrains:platform-api:2020.1.3
-com.jetbrains:util:2020.1.3
+com.jetbrains:mps-core:2020.1.6
+com.jetbrains:mps-environment:2020.1.6
+com.jetbrains:mps-openapi:2020.1.6
+com.jetbrains:mps-platform:2020.1.6
+com.jetbrains:platform-api:2020.1.6
+com.jetbrains:util:2020.1.6

--- a/project-loader/gradle/dependency-locks/default.lockfile
+++ b/project-loader/gradle/dependency-locks/default.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/project-loader/gradle/dependency-locks/default.lockfile
+++ b/project-loader/gradle/dependency-locks/default.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/project-loader/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/project-loader/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/project-loader/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/project-loader/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/project-loader/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,17 +1,17 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0
-com.fasterxml.jackson.core:jackson-core:2.11.0
-com.fasterxml.jackson.core:jackson-databind:2.11.0
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
-com.fasterxml.woodstox:woodstox-core:6.2.0
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11

--- a/project-loader/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,11 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7

--- a/project-loader/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,18 +1,18 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0
-com.fasterxml.jackson.core:jackson-core:2.11.0
-com.fasterxml.jackson.core:jackson-databind:2.11.0
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
-com.fasterxml.woodstox:woodstox-core:6.2.0
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
 junit:junit:4.12
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11

--- a/project-loader/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,17 +1,18 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-junit:junit:4.12
+junit:junit:4.13
 org.codehaus.woodstox:stax2-api:4.2.1
 org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11

--- a/project-loader/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/project-loader/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -1,17 +1,18 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-junit:junit:4.12
+junit:junit:4.13
 org.codehaus.woodstox:stax2-api:4.2.1
 org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11

--- a/project-loader/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/project-loader/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -1,19 +1,22 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-core:2.11.0.rc1
-com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0.rc1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0.rc1
-com.fasterxml.woodstox:woodstox-core:6.1.1
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-org.codehaus.woodstox:stax2-api:4.2
+junit:junit:4.12
+org.codehaus.woodstox:stax2-api:4.2.1
+org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib:1.3.11
 org.jetbrains:annotations:13.0
+org.xmlunit:xmlunit-core:2.6.4

--- a/project-loader/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,18 +1,18 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.0
-com.fasterxml.jackson.core:jackson-core:2.11.0
-com.fasterxml.jackson.core:jackson-databind:2.11.0
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.0
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
-com.fasterxml.woodstox:woodstox-core:6.2.0
+com.fasterxml.jackson.core:jackson-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-core:2.11.1
+com.fasterxml.jackson.core:jackson-databind:2.11.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
 junit:junit:4.12
-org.codehaus.woodstox:stax2-api:4.2
+org.codehaus.woodstox:stax2-api:4.2.1
 org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11

--- a/project-loader/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,17 +1,18 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.11.1
-com.fasterxml.jackson.core:jackson-core:2.11.1
-com.fasterxml.jackson.core:jackson-databind:2.11.1
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
+com.fasterxml.jackson.core:jackson-annotations:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-core:2.12.0-rc1
+com.fasterxml.jackson.core:jackson-databind:2.12.0-rc1
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.0-rc1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.0-rc1
+com.fasterxml.jackson:jackson-bom:2.12.0-rc1
 com.fasterxml.woodstox:woodstox-core:6.2.1
 com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
-junit:junit:4.12
+junit:junit:4.13
 org.codehaus.woodstox:stax2-api:4.2.1
 org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11

--- a/src/main/groovy/de/itemis/mps/gradle/GenerateLibrariesXml.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GenerateLibrariesXml.groovy
@@ -12,7 +12,10 @@ class GenerateLibrariesXml extends DefaultTask {
     @InputFile
     File defaults
 
-    @Optional @InputFile
+    @Optional
+    // currently using @InputFile is not possible due to a failure on non-existing files
+    // TODO: consider using a workaournd with @InputFiles (https://github.com/gradle/gradle/issues/2016)
+    @Input
     File overrides
 
     @OutputFile
@@ -22,11 +25,18 @@ class GenerateLibrariesXml extends DefaultTask {
         description = 'Generates libraries.xml for MPS'
     }
 
+    void setOverrides(Object overrides) {
+        this.overrides = project.file(overrides)
+        if (this.overrides != null && this.overrides.exists()) {
+            inputs.file(overrides)
+        }
+    }
+
     @TaskAction
     def generate() {
         Properties properties = new Properties()
         defaults.withInputStream { properties.load(it) }
-        if (overrides != null && overrides.exists()) {
+        if (overrides.exists()) {
             overrides.withInputStream { properties.load(it) }
         }
         destination.withWriter { writer ->

--- a/src/main/groovy/de/itemis/mps/gradle/GenerateLibrariesXml.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/GenerateLibrariesXml.groovy
@@ -12,7 +12,7 @@ class GenerateLibrariesXml extends DefaultTask {
     @InputFile
     File defaults
 
-    @Optional
+    @Optional @InputFile
     File overrides
 
     @OutputFile
@@ -22,18 +22,11 @@ class GenerateLibrariesXml extends DefaultTask {
         description = 'Generates libraries.xml for MPS'
     }
 
-    void setOverrides(Object overrides) {
-        this.overrides = project.file(overrides)
-        if (this.overrides != null && this.overrides.exists()) {
-            inputs.file(overrides)
-        }
-    }
-
     @TaskAction
     def generate() {
         Properties properties = new Properties()
         defaults.withInputStream { properties.load(it) }
-        if (overrides.exists()) {
+        if (overrides != null && overrides.exists()) {
             overrides.withInputStream { properties.load(it) }
         }
         destination.withWriter { writer ->

--- a/src/test/kotlin/GenerateProjectLibrariesXml.kt
+++ b/src/test/kotlin/GenerateProjectLibrariesXml.kt
@@ -63,13 +63,12 @@ class BuildLogicFunctionalTest {
             
             buildscript {
                 dependencies {
-                    "classpath"(files(${cp.map { """"${it.absolutePath}"""" }.joinToString() }))
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString() }))
                 }
             }
             
             tasks.register<GenerateLibrariesXml>("generateLibs") {
                 defaults = file("projectlibraries.properties")
-                setOverrides(file("projectlibraries.overrides.properties"))
                 destination = file(".mps/libraries.xml")
             }
         """.trimIndent())
@@ -107,13 +106,13 @@ class BuildLogicFunctionalTest {
             
             buildscript {
                 dependencies {
-                    "classpath"(files(${cp.map { """"${it.absolutePath}"""" }.joinToString() }))
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString() }))
                 }
             }
             
             tasks.register<GenerateLibrariesXml>("generateLibs") {
                 defaults = file("projectlibraries.properties")
-                setOverrides(file("projectlibraries.overrides.properties"))
+                overrides = file("projectlibraries.overrides.properties")
                 destination = file(".mps/libraries.xml")
             }
         """.trimIndent())

--- a/src/test/kotlin/GenerateProjectLibrariesXml.kt
+++ b/src/test/kotlin/GenerateProjectLibrariesXml.kt
@@ -69,6 +69,7 @@ class BuildLogicFunctionalTest {
             
             tasks.register<GenerateLibrariesXml>("generateLibs") {
                 defaults = file("projectlibraries.properties")
+                setOverrides(file("projectlibraries.overrides.properties"))
                 destination = file(".mps/libraries.xml")
             }
         """.trimIndent())
@@ -112,7 +113,7 @@ class BuildLogicFunctionalTest {
             
             tasks.register<GenerateLibrariesXml>("generateLibs") {
                 defaults = file("projectlibraries.properties")
-                overrides = file("projectlibraries.overrides.properties")
+                setOverrides(file("projectlibraries.overrides.properties"))
                 destination = file(".mps/libraries.xml")
             }
         """.trimIndent())

--- a/test/generate-build-solution/build.gradle.kts
+++ b/test/generate-build-solution/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 val mps = configurations.create("mps")
-val mpsVersion = "2020.1.3"
+val mpsVersion = "2020.1.6"
 
 dependencies {
     mps("com.jetbrains:mps:$mpsVersion")

--- a/test/generate-build-solution/build.gradle.kts
+++ b/test/generate-build-solution/build.gradle.kts
@@ -2,7 +2,7 @@ group = "test.de.itemis.mps.gradle.generate"
 version = "1.3-SNAPSHOT"
 
 plugins {
-    id("generate-models") version "1.3-SNAPSHOT"
+    id("generate-models") version "1.4-SNAPSHOT"
 }
 
 repositories {
@@ -14,7 +14,7 @@ repositories {
 }
 
 val mps = configurations.create("mps")
-val mpsVersion = "2019.3.2"
+val mpsVersion = "2020.1.3"
 
 dependencies {
     mps("com.jetbrains:mps:$mpsVersion")

--- a/test/generate-build-solution/mps-prj/.mps/.name
+++ b/test/generate-build-solution/mps-prj/.mps/.name
@@ -1,0 +1,1 @@
+generate-build-test

--- a/test/generate-build-solution/mps-prj/solutions/my.solution/my.solution.msd
+++ b/test/generate-build-solution/mps-prj/solutions/my.solution/my.solution.msd
@@ -15,7 +15,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="9" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
@@ -23,7 +23,7 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="4" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/test/generate-simple/build.gradle.kts
+++ b/test/generate-simple/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 val mps = configurations.create("mps")
-val mpsVersion = "2020.1.3"
+val mpsVersion = "2020.1.6"
 
 dependencies {
     mps("com.jetbrains:mps:$mpsVersion")

--- a/test/generate-simple/build.gradle.kts
+++ b/test/generate-simple/build.gradle.kts
@@ -2,7 +2,7 @@ group = "test.de.itemis.mps.gradle.generate"
 version = "1.3-SNAPSHOT"
 
 plugins {
-    id("generate-models") version "1.3-SNAPSHOT"
+    id("generate-models") version "1.4-SNAPSHOT"
 }
 
 repositories {
@@ -14,7 +14,7 @@ repositories {
 }
 
 val mps = configurations.create("mps")
-val mpsVersion = "2019.3.2"
+val mpsVersion = "2020.1.3"
 
 dependencies {
     mps("com.jetbrains:mps:$mpsVersion")

--- a/test/generate-simple/mps-prj/.mps/.name
+++ b/test/generate-simple/mps-prj/.mps/.name
@@ -1,0 +1,1 @@
+generate-simple-test

--- a/test/generate-simple/mps-prj/.mps/vcs.xml
+++ b/test/generate-simple/mps-prj/.mps/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+  </component>
+</project>

--- a/test/generate-simple/mps-prj/solutions/my.solution/my.solution.msd
+++ b/test/generate-simple/mps-prj/solutions/my.solution/my.solution.msd
@@ -15,7 +15,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="9" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
@@ -23,7 +23,7 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="4" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/test/modelcheck/build.gradle.kts
+++ b/test/modelcheck/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 }
 
 var mps = configurations.create("mps")
-val mpsVersion = "2020.1.3"
+val mpsVersion = "2020.1.6"
 
 dependencies{
     mps("com.jetbrains:mps:$mpsVersion")

--- a/test/modelcheck/build.gradle.kts
+++ b/test/modelcheck/build.gradle.kts
@@ -4,7 +4,7 @@ group = "test.de.itemis.mps.gradle.modelcheck"
 version = "1.3-SNAPSHOT"
 
 plugins {
-    id("modelcheck") version "1.3-SNAPSHOT"
+    id("modelcheck") version "1.4-SNAPSHOT"
 }
 
 repositories {
@@ -16,7 +16,7 @@ repositories {
 }
 
 var mps = configurations.create("mps")
-val mpsVersion = "2019.3.2"
+val mpsVersion = "2020.1.3"
 
 dependencies{
     mps("com.jetbrains:mps:$mpsVersion")

--- a/test/modelcheck/mps-prj/.mps/.name
+++ b/test/modelcheck/mps-prj/.mps/.name
@@ -1,0 +1,1 @@
+checkmodel-test

--- a/test/modelcheck/mps-prj/solutions/my.solution.with.errors/models/java.mps
+++ b/test/modelcheck/mps-prj/solutions/my.solution.with.errors/models/java.mps
@@ -2,9 +2,11 @@
 <model ref="r:098fce55-4c9a-4d06-84b9-04b5ca0d51c6(my.solution.with.errors.java)">
   <persistence version="9" />
   <languages>
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="9" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
   </languages>
-  <imports />
+  <imports>
+    <import index="ggvx" ref="r:a73d36b1-a672-4ac9-b2ff-9846b544fa43(my.solution.java)" />
+  </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />

--- a/test/modelcheck/mps-prj/solutions/my.solution.with.errors/my.solution.with.errors.msd
+++ b/test/modelcheck/mps-prj/solutions/my.solution.with.errors/my.solution.with.errors.msd
@@ -6,13 +6,13 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" languageLevel="JAVA_8">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
   <sourcePath />
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="9" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>

--- a/test/modelcheck/mps-prj/solutions/my.solution/my.solution.msd
+++ b/test/modelcheck/mps-prj/solutions/my.solution/my.solution.msd
@@ -6,7 +6,7 @@
     </modelRoot>
   </models>
   <facets>
-    <facet type="java">
+    <facet type="java" languageLevel="JAVA_8">
       <classes generated="true" path="${module}/classes_gen" />
     </facet>
   </facets>
@@ -15,7 +15,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="9" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
@@ -23,7 +23,7 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="4" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />


### PR DESCRIPTION
This PR migrates mps-gradle-plugin to MPS 2020.1.3.

There were no changes related to the MPS start-up classpath configuration for the latest MPS version, which means that the gradle plugin remains compatible with previous MPS version and we don't need to increase the plugin version.
