### PR TITLE
project-loader: reverted change of custom plugins loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Parameters:
 * `javaExec` - optional `java` executable to use.
 * `plugins` - optional list of plugins to load before generation is attempted.
     * The notation is `new Plugin("someID", "somePath", {true|false})`. First parameter is the `plugin id`, second is 
-    `short (folder) name` and the third an optional `pre installed` flag, indicating if the plugins is placed under mps/plugins or not.
+    `short (folder) name` and the third an optional `is custom` flag, indicating if the plugin is placed under custom location.
 * `pluginLocation` - location where to load the plugins from. Structure needs to be a flat folder structure similar to the
   `plugins` directory inside of the MPS installation.
 * `models` - optional list of models to generate. If omitted all models in the project will be generated. Only full name
@@ -272,7 +272,7 @@ Parameters:
 * `javaExec` - optional `java` executable to use.
 * `plugins` - optional list of plugins to load before model check is attempted.
     * The notation is `new Plugin("someID", "somePath", {true|false})`. First parameter is the `plugin id`, second is 
-    `short (folder) name` and the third an optional `pre installed` flag, indicating if the plugins is placed under mps/plugins or not.
+    `short (folder) name` and the third an optional`is custom` flag, indicating if the plugin is placed under custom location.
 * `pluginLocation` - location where to load the plugins from. Structure needs to be a flat folder structure similar to the
   `plugins` directory inside of the MPS installation.
 * `models` - optional list of models to check. RegEx can be used for matching multiple models.
@@ -309,7 +309,7 @@ apply plugin: 'modelcheck'
 
 modelcheck {
     pluginLocation = new File("path/to/my/plugins")
-    plugins = [new Plugin("com.mbeddr.core", "mbeddr.core", false)]
+    plugins = [new Plugin("com.mbeddr.core", "mbeddr.core", true)]
     projectLocation = new File("./mps-prj")
     mpsConfig = configurations.mps
 }
@@ -317,4 +317,4 @@ modelcheck {
 ```
 
 Dependencies of the specified plugins are automatically loaded from the `pluginlocation` by default and the plugins directory of 
-MPS. If the plugin is not located there, the `pre installed` flag needs to be specified. If they are not found the the build will fail.
+MPS. If the plugin is not located there, the `is custom` flag needs to be specified. If they are not found, the the build will fail.

--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ Parameters:
   Custom plugins are supported via the `pluginLocation` parameter.
 * `mpsLocation` - optional location where to place the MPS files.
 * `javaExec` - optional `java` executable to use.
-* `plugins` - optional list of plugins to load before generation is attempted.
-  The notation is `new Plugin("someID", "somePath")`. Where the first parameter is the plugin id and the second the `short (folder) name`.
+* `plugins` - optional list of plugins to load before model check is attempted.
+    * The notation is `new Plugin("someID", "somePath", {true|false})`. First parameter is the `plugin id`, second is 
+    `short (folder) name` and the third an optional `pre installed` flag, indicating if the plugins is placed under mps/plugins or not.
 * `pluginLocation` - location where to load the plugins from. Structure needs to be a flat folder structure similar to the
   `plugins` directory inside of the MPS installation.
 * `models` - optional list of models to generate. If omitted all models in the project will be generated. Only full name
@@ -270,7 +271,8 @@ Parameters:
 * `mpsLocation` - optional location where to place the MPS files.
 * `javaExec` - optional `java` executable to use.
 * `plugins` - optional list of plugins to load before model check is attempted.
-  The notation is `new Plugin("someID", "somePath")`. Where the first parameter is the plugin id and the second the `short (folder) name`.
+    * The notation is `new Plugin("someID", "somePath", {true|false})`. First parameter is the `plugin id`, second is 
+    `short (folder) name` and the third an optional `pre installed` flag, indicating if the plugins is placed under mps/plugins or not.
 * `pluginLocation` - location where to load the plugins from. Structure needs to be a flat folder structure similar to the
   `plugins` directory inside of the MPS installation.
 * `models` - optional list of models to check. RegEx can be used for matching multiple models.
@@ -307,12 +309,12 @@ apply plugin: 'modelcheck'
 
 modelcheck {
     pluginLocation = new File("path/to/my/plugins")
-    plugins = [new Plugin("com.mbeddr.core", "mbeddr.core")]
+    plugins = [new Plugin("com.mbeddr.core", "mbeddr.core", false)]
     projectLocation = new File("./mps-prj")
     mpsConfig = configurations.mps
 }
 
 ```
 
-Dependencies of the specified plugins are automatically loaded from the `pluginlocation` and the plugins directory of 
-MPS. If they are not found the the build will fail.
+Dependencies of the specified plugins are automatically loaded from the `pluginlocation` by default and the plugins directory of 
+MPS. If the plugin is not located there, the `pre installed` flag needs to be specified. If they are not found the the build will fail.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Parameters:
   Custom plugins are supported via the `pluginLocation` parameter.
 * `mpsLocation` - optional location where to place the MPS files.
 * `javaExec` - optional `java` executable to use.
-* `plugins` - optional list of plugins to load before model check is attempted.
+* `plugins` - optional list of plugins to load before generation is attempted.
     * The notation is `new Plugin("someID", "somePath", {true|false})`. First parameter is the `plugin id`, second is 
     `short (folder) name` and the third an optional `pre installed` flag, indicating if the plugins is placed under mps/plugins or not.
 * `pluginLocation` - location where to load the plugins from. Structure needs to be a flat folder structure similar to the

--- a/project-loader/src/main/kotlin/Args.kt
+++ b/project-loader/src/main/kotlin/Args.kt
@@ -18,9 +18,10 @@ private fun <T> splitAndCreatePlugin(str: String, creator: (String, String, Bool
         throw RuntimeException("string is not of the right format. Expected <key>::<value>[::<pre installed>]")
     }
     if (split.size == 3){
+        // in case we can't parse true, toBoolean() will always return false
         return creator(split[0], split[1], split[2].toBoolean())
     }
-    return creator(split[0], split[1], true)
+    return creator(split[0], split[1], false)
 }
 
 private fun toMacro(str: String) = splitAndCreate(str, ::Macro)

--- a/project-loader/src/main/kotlin/Args.kt
+++ b/project-loader/src/main/kotlin/Args.kt
@@ -12,8 +12,19 @@ private fun <T> splitAndCreate(str: String, creator: (String, String) -> T): T {
     return creator(split[0], split[1])
 }
 
+private fun <T> splitAndCreatePlugin(str: String, creator: (String, String, Boolean) -> T): T {
+    val split = str.split("::")
+    if (split.size < 2) {
+        throw RuntimeException("string is not of the right format. Expected <key>::<value>[::<pre installed>]")
+    }
+    if (split.size == 3){
+        return creator(split[0], split[1], split[2].toBoolean())
+    }
+    return creator(split[0], split[1], false)
+}
+
 private fun toMacro(str: String) = splitAndCreate(str, ::Macro)
-private fun toPlugin(str: String) = splitAndCreate(str, ::Plugin)
+private fun toPlugin(str: String) = splitAndCreatePlugin(str, ::Plugin)
 
 /**
  * Default set of arguments required to start a "headless" MPS. This class should be used by other users of the
@@ -23,7 +34,7 @@ private fun toPlugin(str: String) = splitAndCreate(str, ::Plugin)
 open class Args(parser: ArgParser) {
 
     val plugins by parser.adding("--plugin",
-            help = "plugin to to load. The format is --plugin=<id>::<path>")
+            help = "plugin to to load. The format is --plugin=<id>::<path>[::<pre installed>]")
     { toPlugin(this) }
 
     val macros by parser.adding("--macro",

--- a/project-loader/src/main/kotlin/Args.kt
+++ b/project-loader/src/main/kotlin/Args.kt
@@ -18,7 +18,7 @@ private fun <T> splitAndCreatePlugin(str: String, creator: (String, String, Bool
         throw RuntimeException("string is not of the right format. Expected <key>::<value>[::<pre installed>]")
     }
     if (split.size == 3){
-        return creator(split[0], split[1], split[2].toBoolean())
+        return creator(split[0], split[1], split[2].toBoolean() ?: true)
     }
     return creator(split[0], split[1], false)
 }

--- a/project-loader/src/main/kotlin/Args.kt
+++ b/project-loader/src/main/kotlin/Args.kt
@@ -20,7 +20,7 @@ private fun <T> splitAndCreatePlugin(str: String, creator: (String, String, Bool
     if (split.size == 3){
         return creator(split[0], split[1], split[2].toBoolean() ?: true)
     }
-    return creator(split[0], split[1], false)
+    return creator(split[0], split[1], true)
 }
 
 private fun toMacro(str: String) = splitAndCreate(str, ::Macro)

--- a/project-loader/src/main/kotlin/Args.kt
+++ b/project-loader/src/main/kotlin/Args.kt
@@ -18,7 +18,7 @@ private fun <T> splitAndCreatePlugin(str: String, creator: (String, String, Bool
         throw RuntimeException("string is not of the right format. Expected <key>::<value>[::<pre installed>]")
     }
     if (split.size == 3){
-        return creator(split[0], split[1], split[2].toBoolean() ?: true)
+        return creator(split[0], split[1], split[2].toBoolean())
     }
     return creator(split[0], split[1], true)
 }

--- a/project-loader/src/main/kotlin/Loader.kt
+++ b/project-loader/src/main/kotlin/Loader.kt
@@ -1,6 +1,5 @@
 package de.itemis.mps.gradle.project.loader
 
-import com.intellij.openapi.application.PathMacros
 import jetbrains.mps.project.Project
 import jetbrains.mps.tool.environment.EnvironmentConfig
 import jetbrains.mps.tool.environment.IdeaEnvironment
@@ -11,7 +10,7 @@ import java.io.File
 data class Plugin(
         val id: String,
         val path: String,
-        val isPreInstalled: Boolean
+        val isCustom: Boolean
 )
 
 data class Macro(
@@ -101,10 +100,10 @@ fun <T> executeWithProject(project: File,
 
     val cfg = basicEnvironmentConfig()
     plugins.forEach {
-        if (it.isPreInstalled) {
-            cfg.addPreInstalledPlugin(it.path, it.id)
-        } else {
+        if (it.isCustom) {
             cfg.addPlugin(it.path, it.id)
+        } else {
+            cfg.addPreInstalledPlugin(it.path, it.id)
         }
     }
 

--- a/project-loader/src/main/kotlin/Loader.kt
+++ b/project-loader/src/main/kotlin/Loader.kt
@@ -101,7 +101,7 @@ fun <T> executeWithProject(project: File,
 
     val cfg = basicEnvironmentConfig()
     plugins.forEach {
-        if (it.isPreInstalled != null && it.isPreInstalled) {
+        if (it.isPreInstalled) {
             cfg.addPreInstalledPlugin(it.path, it.id)
         } else {
             cfg.addPlugin(it.path, it.id)

--- a/project-loader/src/main/kotlin/Loader.kt
+++ b/project-loader/src/main/kotlin/Loader.kt
@@ -11,7 +11,7 @@ import java.io.File
 data class Plugin(
         val id: String,
         val path: String,
-        val isPreInstalled: Boolean?=null
+        val isPreInstalled: Boolean
 )
 
 data class Macro(

--- a/project-loader/src/main/kotlin/Loader.kt
+++ b/project-loader/src/main/kotlin/Loader.kt
@@ -100,7 +100,7 @@ fun <T> executeWithProject(project: File,
 
     val cfg = basicEnvironmentConfig()
 
-    plugins.forEach { cfg.addPreInstalledPlugin(it.path, it.id) }
+    plugins.forEach { cfg.addPlugin(it.path, it.id) }
     macros.forEach { cfg.addMacro(it.name, File(it.value)) }
 
     val ideaEnvironment = IdeaEnvironment(cfg)

--- a/src/main/kotlin/de/itemis/mps/gradle/Common.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/Common.kt
@@ -10,7 +10,8 @@ private val logger = Logger.getLogger("de.itemis.mps.gradle.common")
 
 data class Plugin(
         var id: String,
-        var path: String
+        var path: String,
+        var isPreInstalled:Boolean? = null
 )
 
 data class Macro(
@@ -45,7 +46,10 @@ fun argsFromBaseExtension(extensions: BasePluginExtensions): MutableList<String>
     val prj = sequenceOf("--project=${projectLocation.absolutePath}")
 
     return sequenceOf(pluginLocation,
-            extensions.plugins.map { "--plugin=${it.id}::${it.path}" }.asSequence(),
+            extensions.plugins.map {
+               val preInstalled = if ( it.isPreInstalled != null) "::${it.isPreInstalled}" else ""
+                "--plugin=${it.id}::${it.path}" + preInstalled
+            }.asSequence(),
             extensions.macros.map { "--macro=${it.name}::${it.value}" }.asSequence(),
             prj).flatten().toMutableList()
 }

--- a/src/main/kotlin/de/itemis/mps/gradle/Common.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/Common.kt
@@ -11,7 +11,7 @@ private val logger = Logger.getLogger("de.itemis.mps.gradle.common")
 data class Plugin(
         var id: String,
         var path: String,
-        var isPreInstalled:Boolean? = null
+        var isCustom:Boolean? = null
 )
 
 data class Macro(
@@ -47,8 +47,8 @@ fun argsFromBaseExtension(extensions: BasePluginExtensions): MutableList<String>
 
     return sequenceOf(pluginLocation,
             extensions.plugins.map {
-               val preInstalled = if ( it.isPreInstalled != null) "::${it.isPreInstalled}" else ""
-                "--plugin=${it.id}::${it.path}" + preInstalled
+               val custom = if ( it.isCustom != null) "::${it.isCustom}" else ""
+                "--plugin=${it.id}::${it.path}" + custom
             }.asSequence(),
             extensions.macros.map { "--macro=${it.name}::${it.value}" }.asSequence(),
             prj).flatten().toMutableList()


### PR DESCRIPTION
A list of custom plugins is now added directy to the environment
without the usage of the pre installed plugins path
Fixes #76 