### PR TITLE
align fastxml version with version shipped in MPS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ val nexusPassword: String? by project
 
 val kotlinArgParserVersion by extra { "2.0.7" }
 val mpsVersion by extra { "2019.3.7" }
+//this version needs to align with the version shiped with MPS found in the /lib folder otherwise, runtime problems will
+//surface because mismatching jars on the classpath.
+val fastXmlJacksonVersion by extra { "2.10.+" }
 
 
 version = if (!project.hasProperty("useSnapshot") &&

--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -23,6 +23,7 @@ val nexusPassword: String? by project
 
 val kotlinArgParserVersion: String by project
 val mpsVersion: String by project
+val fastXmlJacksonVersion: String by project
 
 val kotlinApiVersion: String by project
 val kotlinVersion: String by project
@@ -42,7 +43,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8", version = kotlinVersion))
     implementation(kotlin("test", version = kotlinVersion))
     implementation("com.xenomachina:kotlin-argparser:$kotlinArgParserVersion")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.+")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$fastXmlJacksonVersion")
     compileOnly("com.jetbrains:mps-openapi:$mpsVersion")
     compileOnly("com.jetbrains:mps-core:$mpsVersion")
     compileOnly("com.jetbrains:mps-modelchecker:$mpsVersion")

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -16,6 +16,7 @@ val kotlinVersion: String by project
 
 val nexusUsername: String? by project
 val nexusPassword: String? by project
+val fastXmlJacksonVersion: String by project
 
 val pluginVersion = "1"
 
@@ -37,7 +38,7 @@ repositories {
 dependencies {
     implementation(kotlin("stdlib-jdk8", version = kotlinVersion))
     implementation("com.xenomachina:kotlin-argparser:$kotlinArgParserVersion")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.+")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$fastXmlJacksonVersion")
     compileOnly("com.jetbrains:mps-core:$mpsVersion")
     compileOnly("com.jetbrains:mps-environment:$mpsVersion")
     compileOnly("com.jetbrains:mps-platform:$mpsVersion")


### PR DESCRIPTION
MPS 2019.3 now ships with fastxml as well and they use the version 2.10. Since the modelcheck tasks uses fastxml as  well and shares the classpath with MPS we need to make sure we use the exact same version MPS to avoid problems at runtime. 