### PR TITLE
inherit logging from gradle to mps

### DIFF
--- a/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import java.util.*
 
 open class RunAntScript : DefaultTask() {
     @Input
@@ -43,7 +44,7 @@ open class RunAntScript : DefaultTask() {
         }
 
         if(logging.level != LogLevel.LIFECYCLE && !allArgs.any { it.contains("mps\\.ant\\.log") }) {
-            allArgs = allArgs + "-Dmps.ant.log=${logging.level.toString().toLowerCase()}"
+            allArgs = allArgs + "-Dmps.ant.log=${logging.level.toString().toLowerCase(Locale.ENGLISH)}"
         }
 
         project.javaexec {

--- a/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
@@ -2,6 +2,7 @@ package de.itemis.mps.gradle;
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
@@ -39,6 +40,10 @@ open class RunAntScript : DefaultTask() {
             if (defaultArgs != null) {
                 allArgs = allArgs + defaultArgs.map { it as String }
             }
+        }
+
+        if(logging.level != LogLevel.LIFECYCLE && !allArgs.any { it.contains("mps\\.ant\\.log") }) {
+            allArgs = allArgs + "-Dmps.ant.log=${logging.level.toString().toLowerCase()}"
         }
 
         project.javaexec {

--- a/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/RunAntScript.kt
@@ -43,7 +43,7 @@ open class RunAntScript : DefaultTask() {
             }
         }
 
-        if(logging.level != LogLevel.LIFECYCLE && !allArgs.any { it.contains("mps\\.ant\\.log") }) {
+        if(logging.level != LogLevel.LIFECYCLE && !allArgs.any { it.startsWith("-Dmps.ant.log=") }) {
             allArgs = allArgs + "-Dmps.ant.log=${logging.level.toString().toLowerCase(Locale.ENGLISH)}"
         }
 


### PR DESCRIPTION
RunAntScript: inherit gradle log level

adds support for the new "mps.ant.log" property to the RunAntScript tasks.
The property is used in MPS build scripts generated with MPS 2020.2+
to set the log level during generation. For older versions it is
simply ignored.

The logic in RunAntScript checks if the current log level for the task
is set to anything different than "LIFECYCLE" which is the default and
sets property accordingly when it detects a none default level.

This allows settings the log level via gradle either via command line
e.g. -w, -i or -d or on task level in the build script.

I wasn't able to find a sane way to test this because I would have to use MPS generated ant scripts to test it properly. This seems like an overkill to test a log4j log level string. String representation for the default log levels should be the same anyway and we don't pass the gradle specific "LIFECYCLE" level to ant. 