### PR TITLE
generate, modelcheck: allow using custom MPS

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [1.8, 11, 13]
+        java: [11, 13]
 
     steps:
     - uses: actions/checkout@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 val versionMajor = 1
-val versionMinor = 4
+val versionMinor = 5
 
 group = "de.itemis.mps"
 

--- a/execute-generators/build.gradle.kts
+++ b/execute-generators/build.gradle.kts
@@ -24,7 +24,7 @@ val kotlinArgParserVersion: String by project
 val mpsVersion: String by project
 
 val kotlinApiVersion: String by project
-val kotlinVersion: String by project
+val kotlinVersion: String   by project
 
 val pluginVersion = "2"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/Common.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/Common.kt
@@ -4,9 +4,12 @@ import org.apache.log4j.Logger
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.artifacts.Configuration
+import org.gradle.initialization.GradleLauncher
 import java.io.File
 
 private val logger = Logger.getLogger("de.itemis.mps.gradle.common")
+
+const val MPS_SUPPORT_MSG = "Version 1.5 doesn't only support MPS 2020.1+, please use versions 1.4 or below with older versions of MPS."
 
 data class Plugin(
         var id: String,
@@ -19,8 +22,9 @@ data class Macro(
 )
 
 open class BasePluginExtensions {
-    lateinit var mpsConfig: Configuration
+    var mpsConfig: Configuration? = null
     var mpsLocation: File? = null
+    var mpsVersion: String? = null
     var plugins: List<Plugin> = emptyList()
     var pluginLocation: File? = null
     var macros: List<Macro> = emptyList()
@@ -48,4 +52,28 @@ fun argsFromBaseExtension(extensions: BasePluginExtensions): MutableList<String>
             extensions.plugins.map { "--plugin=${it.id}::${it.path}" }.asSequence(),
             extensions.macros.map { "--macro=${it.name}::${it.value}" }.asSequence(),
             prj).flatten().toMutableList()
+}
+
+fun BasePluginExtensions.getMPSVersion(): String {
+    /*
+    If the user supplies a MPS config we use this one to resolve MPS and get the version. For other scenarios the user
+    can supply mpsLocation and mpsVersion then we do not resolve anything and the users build script is responsible for
+    resolving a compatible MPS into th mpsLocation before the
+     */
+    if(mpsConfig != null) {
+        return mpsConfig!!
+            .resolvedConfiguration
+            .firstLevelModuleDependencies.find { it.moduleGroup == "com.jetbrains" && it.moduleName == "mps" }
+            ?.moduleVersion ?: throw GradleException("MPS configuration doesn't contain MPS")
+    }
+
+    if(mpsVersion != null) {
+        if(mpsLocation == null) {
+            throw GradleException("Setting an MPS version but no MPS location is not supported!")
+        }
+        return mpsVersion!!
+    }
+
+    throw GradleException("Either mpsConfig or mpsVersion needs to specified!")
+
 }

--- a/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
@@ -1,11 +1,10 @@
 package de.itemis.mps.gradle.modelcheck
 
-import de.itemis.mps.gradle.BasePluginExtensions
-import de.itemis.mps.gradle.argsFromBaseExtension
-import de.itemis.mps.gradle.validateDefaultJvm
+import de.itemis.mps.gradle.*
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.JavaExec
 import org.gradle.kotlin.dsl.support.zipTo
@@ -13,7 +12,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.zip.ZipInputStream
 
-open class ModelCheckPluginExtensions: BasePluginExtensions() {
+open class ModelCheckPluginExtensions : BasePluginExtensions() {
     var models: List<String> = emptyList()
     var modules: List<String> = emptyList()
     var warningAsError = false
@@ -31,11 +30,7 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
             afterEvaluate {
                 val mpsLocation = extension.mpsLocation ?: File(project.buildDir, "mps")
 
-                val mpsVersion = extension
-                        .mpsConfig
-                        .resolvedConfiguration
-                        .firstLevelModuleDependencies.find { it.moduleGroup == "com.jetbrains" && it.moduleName == "mps" }
-                        ?.moduleVersion ?: throw GradleException("MPS configuration doesn't contain MPS")
+                val mpsVersion = extension.getMPSVersion()
 
                 // this dependency will never resolve against SNAPSHOT version, if there is a previously released version for $mpsVersion
                 // hence if testing SNAPSHOT version locally, replace '+' with '.[pluginVersion]-SNAPSHOT', e.g. '.2-SNAPSHOT'
@@ -43,12 +38,16 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
                 val dep = project.dependencies.create("de.itemis.mps:modelcheck:$mpsVersion+")
                 val genConfig = configurations.detachedConfiguration(dep)
 
+                if(mpsVersion.substring(0..3).toInt() < 2020) {
+                    throw GradleException(MPS_SUPPORT_MSG)
+                }
+
                 val args = argsFromBaseExtension(extension)
 
                 args.addAll(extension.models.map { "--model=$it" }.asSequence())
                 args.addAll(extension.modules.map { "--module=$it" }.asSequence())
 
-                if(extension.warningAsError) {
+                if (extension.warningAsError) {
                     args.add("--warning-as-error")
                 }
 
@@ -64,36 +63,17 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
                     args.add("--result-format=${extension.junitFormat}")
                 }
 
-                val resolveMps = tasks.create("resolveMpsForModelcheck", Copy::class.java) {
-                    from(extension.mpsConfig.resolve().map { zipTree(it) })
-                    /*
-                    Some 2019.2 src jars cause MPS startup to fail with an exception during indexing
-                    because of the wrong specification in module.xml -> we remove those broken parts as a workaround.
-                    In MPS 2019.3 those src jars are already removed.
-                     */
-                    val modelsTagRegEx = Regex("<models>.*</models>", RegexOption.DOT_MATCHES_ALL)
-                    val replaceTag = "<models/>"
-                    filesMatching(listOf("**/runtimes/*.feedback.*-src.jar", "**/runtimes/*.messages.api-src.jar")) {
-                        ZipInputStream(open()).use { zis ->
-                            val resultEntries = ArrayList<Pair<String, ByteArray>>()
-                            do {
-                                val nextEntry = zis.nextEntry ?: break
-                                val outputStream = ByteArrayOutputStream()
-                                zis.copyTo(outputStream)
-                                var byteArray : ByteArray
-                                if (nextEntry.name.contains(".msd")) {
-                                    byteArray = outputStream.toString().replace(modelsTagRegEx, replaceTag).toByteArray()
-                                } else {
-                                    byteArray = outputStream.toByteArray()
-                                }
-                                resultEntries.add(Pair(nextEntry.name, byteArray))
-                            } while (true)
-                            zipTo(File(mpsLocation, this.path), resultEntries.asSequence())
-                        }
-                        exclude()
+
+                val resolveMps: Task = if (extension.mpsConfig != null) {
+                    tasks.create("resolveMpsForModelcheck", Copy::class.java) {
+                        from(extension.mpsConfig!!.resolve().map { zipTree(it) })
+                        into(mpsLocation)
                     }
-                    into(mpsLocation)
+                } else {
+                    tasks.create("resolveMpsForModelcheck")
                 }
+
+
                 tasks.create("checkmodels", JavaExec::class.java) {
                     dependsOn(resolveMps)
                     args(args)
@@ -113,7 +93,13 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
                     // mps-httpsupport: we need it to print the node url to the console.
                     // mps-modelchecker: contains used UnresolvedReferencesChecker
                     // git4idea: has to be on classpath as bundled plugin to be loaded (since 2019.3)
-                    classpath(fileTree(File(mpsLocation, "/plugins")).include("mps-modelchecker/**/*.jar", "mps-httpsupport/**/*.jar", "git4idea/**/*.jar"))
+                    classpath(
+                        fileTree(File(mpsLocation, "/plugins")).include(
+                            "mps-modelchecker/**/*.jar",
+                            "mps-httpsupport/**/*.jar",
+                            "git4idea/**/*.jar"
+                        )
+                    )
                     classpath(genConfig)
                     debug = extension.debug
                     main = "de.itemis.mps.gradle.modelcheck.MainKt"

--- a/src/test/kotlin/test/de/itemis/mps/gradle/GenerateModelsTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/GenerateModelsTest.kt
@@ -1,0 +1,317 @@
+package test.de.itemis.mps.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.*
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class GenerateModelsTest {
+    @Rule
+    @JvmField
+    val testProjectDir: TemporaryFolder = TemporaryFolder()
+    private lateinit var settingsFile: File
+    private lateinit var buildFile: File
+    private lateinit var cp: List<File>
+    private lateinit var mpsTestPrjLocation: File
+
+
+    @Before
+    fun setup() {
+        settingsFile = testProjectDir.newFile("settings.gradle.kts")
+        buildFile = testProjectDir.newFile("build.gradle.kts")
+        cp = javaClass.classLoader.getResource(
+            "plugin-classpath.txt"
+        )!!.readText().lines().map { File(it) }
+        mpsTestPrjLocation = testProjectDir.newFolder("mps-prj")
+        ProjectHelper().extractTestProject(mpsTestPrjLocation)
+    }
+
+    @Test
+    @Ignore
+    fun `generate works with latest MPS`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("generate-models")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            generate {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsConfig = mps
+            }
+        """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("generate")
+            .withPluginClasspath(cp)
+            .build()
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generate")?.outcome)
+    }
+    @Test
+    fun `generate fails with unsupported MPS`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("generate-models")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2019.3.3")
+            }
+            
+            generate {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsConfig = mps
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("generate")
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+    @Test
+    fun `generate works with set MPS version and path`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("generate-models")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            generate {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsVersion = "2020.2.2"
+                mpsLocation = file(".")
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments()
+            .withPluginClasspath(cp)
+            .build()
+    }
+
+    @Test
+    fun `generate fails with set MPS invalid version and path`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("generate-models")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            generate {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsVersion = "2019.2.2"
+                mpsLocation = file(".")
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments()
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+    @Test
+    fun `generate fails with only MPS version set`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("generate-models")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            generate {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsVersion = "2020.2.2"
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments()
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+    @Test
+    fun `generate fails with only MPS path set`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("generate-models")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            generate {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsLocation = file(".")
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments()
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+}

--- a/src/test/kotlin/test/de/itemis/mps/gradle/GenerateProjectLibrariesXmlTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/GenerateProjectLibrariesXmlTest.kt
@@ -1,3 +1,4 @@
+package test.de.itemis.mps.gradle
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -9,6 +10,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import kotlin.jvm.JvmField
 import java.io.File
+
 
 
 fun getExpectedLibContent(vars: List<Pair<String, String>>): String {
@@ -31,7 +33,7 @@ fun getExpectedLibContent(vars: List<Pair<String, String>>): String {
 </project>"""
 }
 
-class BuildLogicFunctionalTest {
+class GenerateProjectLibrariesXmlTest {
 
     @Rule @JvmField
     val testProjectDir: TemporaryFolder = TemporaryFolder()

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -1,3 +1,5 @@
+package test.de.itemis.mps.gradle
+
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert

--- a/src/test/kotlin/test/de/itemis/mps/gradle/ModelCheckTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/ModelCheckTest.kt
@@ -1,0 +1,330 @@
+package test.de.itemis.mps.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ModelCheckTest {
+    @Rule
+    @JvmField
+    val testProjectDir: TemporaryFolder = TemporaryFolder()
+    private lateinit var settingsFile: File
+    private lateinit var buildFile: File
+    private lateinit var cp: List<File>
+    private lateinit var mpsTestPrjLocation: File
+    private lateinit var junitFile: File
+
+
+    @Before
+    fun setup() {
+        settingsFile = testProjectDir.newFile("settings.gradle.kts")
+        buildFile = testProjectDir.newFile("build.gradle.kts")
+        cp = javaClass.classLoader.getResource(
+            "plugin-classpath.txt"
+        )!!.readText().lines().map { File(it) }
+        mpsTestPrjLocation = testProjectDir.newFolder("mps-prj")
+        ProjectHelper().extractTestProject(mpsTestPrjLocation)
+        junitFile = File(mpsTestPrjLocation, "junit.xml")
+    }
+
+    @Test
+    fun `check model works with latest MPS`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("modelcheck")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            modelcheck {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsConfig = mps
+                junitFile = file("${junitFile.absolutePath}")
+            }
+        """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("checkmodels")
+            .withPluginClasspath(cp)
+            .build()
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":checkmodels")?.outcome)
+        Assert.assertTrue(junitFile.exists())
+    }
+    @Test
+    fun `check model fails with unsupported MPS`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("modelcheck")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2019.3.3")
+            }
+            
+            modelcheck {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsConfig = mps
+                junitFile = file("${junitFile.absolutePath}")
+
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("checkmodels")
+            .withPluginClasspath(cp)
+            .buildAndFail()
+        Assert.assertFalse(junitFile.exists())
+    }
+    @Test
+    fun `check model works with set MPS version and path`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("modelcheck")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            modelcheck {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsVersion = "2020.2.2"
+                mpsLocation = file(".")
+                junitFile = file("${junitFile.absolutePath}")
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments()
+            .withPluginClasspath(cp)
+            .build()
+    }
+
+    @Test
+    fun `check model fails with set MPS invalid version and path`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("modelcheck")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            modelcheck {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsVersion = "2019.2.2"
+                mpsLocation = file(".")
+                junitFile = file("${junitFile.absolutePath}")
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments()
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+    @Test
+    fun `check model fails with only MPS version set`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("modelcheck")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            modelcheck {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsVersion = "2020.2.2"
+                junitFile = file("${junitFile.absolutePath}")
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments()
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+    @Test
+    fun `check model fails with only MPS path set`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+
+        buildFile.writeText(
+            """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("modelcheck")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            val mps = configurations.create("mps")
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.3")
+            }
+            
+            modelcheck {
+                projectLocation = file("${mpsTestPrjLocation.toPath()}")
+                mpsLocation = file(".")
+                junitFile = file("${junitFile.absolutePath}")
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments()
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+}

--- a/src/test/kotlin/test/de/itemis/mps/gradle/ProjectHelper.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/ProjectHelper.kt
@@ -1,0 +1,21 @@
+package test.de.itemis.mps.gradle
+
+import java.io.File
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.streams.toList
+
+class ProjectHelper {
+
+    fun extractTestProject(to: File) {
+        val url = this.javaClass.classLoader.getResource("test-project")
+        val path = Paths.get(url.toURI())
+        val files = Files.walk(path).filter { Files.isRegularFile(it) }.map { it.toFile() }.toList()
+        files.forEach {
+            val rel = path.relativize(it.toPath())
+            it.copyTo(to.toPath().resolve(rel).toFile())
+        }
+    }
+
+}

--- a/src/test/resources/test-project/.mps/.gitignore
+++ b/src/test/resources/test-project/.mps/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/src/test/resources/test-project/.mps/migration.xml
+++ b/src/test/resources/test-project/.mps/migration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MigrationProperties">
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+  </component>
+</project>

--- a/src/test/resources/test-project/.mps/misc.xml
+++ b/src/test/resources/test-project/.mps/misc.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownProjectSettings">
+    <PreviewSettings splitEditorLayout="SPLIT" splitEditorPreview="PREVIEW" useGrayscaleRendering="false" zoomFactor="1.0" maxImageWidth="0" synchronizePreviewPosition="true" highlightPreviewType="LINE" highlightFadeOut="5" highlightOnTyping="true" synchronizeSourcePosition="true" verticallyAlignSourceAndPreviewSyncPosition="true" showSearchHighlightsInPreview="true" showSelectionInPreview="true" lastLayoutSetsDefault="false">
+      <PanelProvider>
+        <provider providerId="com.vladsch.md.nav.editor.swing.html.panel" providerName="Default - Swing" />
+      </PanelProvider>
+    </PreviewSettings>
+    <ParserSettings gitHubSyntaxChange="false" correctedInvalidSettings="false" emojiShortcuts="1" emojiImages="0">
+      <PegdownExtensions>
+        <option name="ANCHORLINKS" value="true" />
+        <option name="ATXHEADERSPACE" value="true" />
+        <option name="FENCED_CODE_BLOCKS" value="true" />
+        <option name="INTELLIJ_DUMMY_IDENTIFIER" value="true" />
+        <option name="RELAXEDHRULES" value="true" />
+        <option name="STRIKETHROUGH" value="true" />
+        <option name="TABLES" value="true" />
+        <option name="TASKLISTITEMS" value="true" />
+      </PegdownExtensions>
+      <ParserOptions>
+        <option name="COMMONMARK_LISTS" value="true" />
+        <option name="EMOJI_SHORTCUTS" value="true" />
+        <option name="GFM_TABLE_RENDERING" value="true" />
+        <option name="PRODUCTION_SPEC_PARSER" value="true" />
+        <option name="SIM_TOC_BLANK_LINE_SPACER" value="true" />
+      </ParserOptions>
+    </ParserSettings>
+    <HtmlSettings headerTopEnabled="false" headerBottomEnabled="false" bodyTopEnabled="false" bodyBottomEnabled="false" addPageHeader="false" imageUriSerials="false" addDocTypeHtml="true" noParaTags="false" plantUmlConversion="0">
+      <GeneratorProvider>
+        <provider providerId="com.vladsch.md.nav.editor.text.html.generator" providerName="Unmodified HTML Generator" />
+      </GeneratorProvider>
+      <headerTop />
+      <headerBottom />
+      <bodyTop />
+      <bodyBottom />
+    </HtmlSettings>
+    <CssSettings previewScheme="UI_SCHEME" cssUri="" isCssUriEnabled="false" isCssUriSerial="true" isCssTextEnabled="false" isDynamicPageWidth="true">
+      <StylesheetProvider>
+        <provider providerId="com.vladsch.md.nav.editor.text.html.css" providerName="No Stylesheet" />
+      </StylesheetProvider>
+      <ScriptProviders />
+      <cssText />
+      <cssUriHistory />
+    </CssSettings>
+  </component>
+</project>

--- a/src/test/resources/test-project/.mps/modules.xml
+++ b/src/test/resources/test-project/.mps/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MPSProject">
+    <projectModules>
+      <modulePath path="$PROJECT_DIR$/solutions/NewSolution/NewSolution.msd" folder="" />
+    </projectModules>
+  </component>
+</project>

--- a/src/test/resources/test-project/.mps/vcs.xml
+++ b/src/test/resources/test-project/.mps/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../../.." vcs="Git" />
+  </component>
+</project>

--- a/src/test/resources/test-project/solutions/NewSolution/NewSolution.msd
+++ b/src/test/resources/test-project/solutions/NewSolution/NewSolution.msd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="NewSolution" uuid="c8280d06-5919-4f51-97f9-263af08eef9c" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="c8280d06-5919-4f51-97f9-263af08eef9c(NewSolution)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/src/test/resources/test-project/solutions/NewSolution/models/NewSolution.myModel.mps
+++ b/src/test/resources/test-project/solutions/NewSolution/models/NewSolution.myModel.mps
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:af6f35d8-185e-4ea3-b48c-f8a20dc88a20(NewSolution.myModel)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="1wd9AaS6sTY">
+    <property role="TrG5h" value="MyClass" />
+    <node concept="2YIFZL" id="1wd9AaS6w0$" role="jymVt">
+      <property role="TrG5h" value="main" />
+      <node concept="37vLTG" id="1wd9AaS6w0_" role="3clF46">
+        <property role="TrG5h" value="args" />
+        <node concept="10Q1$e" id="1wd9AaS6w0A" role="1tU5fm">
+          <node concept="17QB3L" id="1wd9AaS6w0B" role="10Q1$1" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="1wd9AaS6w0C" role="3clF45" />
+      <node concept="3Tm1VV" id="1wd9AaS6w0D" role="1B3o_S" />
+      <node concept="3clFbS" id="1wd9AaS6w0E" role="3clF47">
+        <node concept="3clFbF" id="1wd9AaS6w62" role="3cqZAp">
+          <node concept="2OqwBi" id="1wd9AaS6w5Z" role="3clFbG">
+            <node concept="10M0yZ" id="1wd9AaS6w60" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="1wd9AaS6w61" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="Xl_RD" id="1wd9AaS6x_Z" role="37wK5m">
+                <property role="Xl_RC" value="Hello World!" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1wd9AaS6sTZ" role="1B3o_S" />
+  </node>
+</model>
+


### PR DESCRIPTION
Adds support for the custom distributions of MPS vai new property
mpsVersion which is used to resolve the runtime dependency.

Cleanup the code responsible for resolving MPS and removed the logic
to handle an edge case in 2019.2. This causes the plugin to be no longer
compatible with MPS versions lower than 2019.3. The plugin checks the MPS
version and presents an error is its older than 2020.1. The minor version
of the plugin was increased because of that.

Tests were added that contain test project for modelcheck and generate
tasks. One test is ignored because resoving the runtime dependency is still
tricky and not 100% solved. Never the less I wanted to get the feature into
review this week. We can merge it without that test case for now and
revamp the versioning of the runtime part later on.

The readme contains an overview how users can use their custom MPS.