### PR TITLE
Recent changes to the launcher in intellij platform seem to no longer…

### DIFF
--- a/src/main/groovy/de/itemis/mps/gradle/BundleMacosJdk.groovy
+++ b/src/main/groovy/de/itemis/mps/gradle/BundleMacosJdk.groovy
@@ -4,12 +4,16 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 class BundleMacosJdk extends DefaultTask {
     @InputFile
     File rcpArtifact
+
+    @Optional
+    String jdkDirname  = "jre"
 
     @InputFile
     File jdk
@@ -19,6 +23,10 @@ class BundleMacosJdk extends DefaultTask {
 
     def setRcpArtifact(Object file) {
         this.rcpArtifact = project.file(file)
+    }
+
+    def setJdkDirname(String dirname) {
+        this.jdkDirname = dirname
     }
 
     def setJdk(Object file) {
@@ -45,6 +53,7 @@ class BundleMacosJdk extends DefaultTask {
 
     @TaskAction
     def build() {
+        project.logger.lifecycle("The jdkDirname: ${jdkDirname}")
         File scriptsDir = File.createTempDir()
         File tmpDir = File.createTempDir()
         try {
@@ -52,7 +61,7 @@ class BundleMacosJdk extends DefaultTask {
             BundledScripts.extractScriptsToDir(scriptsDir, scriptName)
             project.exec {
                 executable new File(scriptsDir, scriptName)
-                args rcpArtifact, tmpDir, jdk, outputFile
+                args rcpArtifact, tmpDir, jdkDirname, jdk, outputFile
                 workingDir scriptsDir
             }
         } finally {

--- a/src/main/resources/de/itemis/mps/gradle/bundle_macos_jdk.sh
+++ b/src/main/resources/de/itemis/mps/gradle/bundle_macos_jdk.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-if [[ $# -ne 4 ]]; then
+if [[ $# -ne 5 ]]; then
   cat <<EOF
 Usage:
 
-  $0 RCP_FILE TMP_DIR JDK_FILE OUT_FILE
+  $0 RCP_FILE TMP_DIR JDK_DIRNAME JDK_FILE OUT_FILE
 
 1. Extracts RCP_FILE into TMP_DIR
 2. Creates symlinks Contents/bin/*.dylib -> *.jnilib if any .jnilib files are present
    (this used to be the case for earlier versions of MPS)
-3. If JDK_FILE is given, extracts JDK_FILE under Contents/jre/
+3. If JDK_FILE is given, extracts JDK_FILE under Contents/$JDK_DIRNAME/
 4. Sets executable permissions on Contents/MacOS/* and appropriate Contents/bin/ files
 5. Compresses the result into OUT_FILE (tar/gzip)
 
@@ -22,8 +22,9 @@ set -o errexit # Exit immediately on any error
 # Arguments
 RCP_FILE="$1"
 TMP_DIR="$2"
-JDK_FILE="$3"
-OUT_FILE="$4"
+JDK_DIRNAME="$3"
+JDK_FILE="$4"
+OUT_FILE="$5"
 
 echo "Unzipping $RCP_FILE to $TMP_DIR..."
 unzip -q -o "$RCP_FILE" -d "$TMP_DIR"
@@ -59,9 +60,9 @@ if [[ -n "$JDK_FILE" ]]; then
   rm -f "$CONTENTS/Info.plist-e"
   echo "Info.plist has been modified"
 
-  echo "Extracting JDK: $JDK_FILE to $CONTENTS/jre"
-  mkdir -p "$CONTENTS/jre"
-  pushd "$CONTENTS/jre"
+  echo "Extracting JDK: $JDK_FILE to $CONTENTS/$JDK_DIRNAME"
+  mkdir -p "$CONTENTS/$JDK_DIRNAME"
+  pushd "$CONTENTS/$JDK_DIRNAME"
   COPY_EXTENDED_ATTRIBUTES_DISABLE=true COPYFILE_DISABLE=true tar xvf "$JDK_FILE" --exclude='._jdk' || exit 1
   echo "JDK has been extracted"
   popd


### PR DESCRIPTION
… support bundled java runtimes in locations such as:

   jre
   jdk

When bundling in this format, you will get a message "No matching VM found" from the Launcher