### PR TITLE
Remove chmod command on *.py files during MacOS bundle

### DIFF
--- a/src/main/resources/de/itemis/mps/gradle/bundle_macos_jdk.sh
+++ b/src/main/resources/de/itemis/mps/gradle/bundle_macos_jdk.sh
@@ -69,7 +69,6 @@ if [[ -n "$JDK_FILE" ]]; then
 fi
 
 chmod a+x "$CONTENTS"/MacOS/*
-chmod a+x "$CONTENTS"/bin/*.py
 chmod a+x "$CONTENTS"/bin/fs*
 chmod a+x "$CONTENTS"/bin/restarter
 


### PR DESCRIPTION
Seems like *.py files no longer exist in `$CONTENTS"/bin/`..
Need to get rid of this command or else the build would fail.