### PR TITLE
Publish modelcheck and project-loader to GHP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,26 +97,27 @@ tasks {
     }
 }
 
-publishing {
-    repositories {
-        maven {
-            name = "itemis"
-            url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr")
-            credentials {
-                username = nexusUsername
-                password = nexusPassword
-            }
-        }
-    }
-    repositories {
-        if(currentBranch == "master" || currentBranch!!.startsWith("mps")) {
+allprojects {
+    apply<MavenPublishPlugin>()
+    publishing {
+        repositories {
             maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/mbeddr/mps-gradle-plugin")
-                if(project.hasProperty("gpr.token")) {
-                    credentials {
-                        username = project.findProperty("gpr.user") as String?
-                        password = project.findProperty("gpr.token") as String?
+                name = "itemis"
+                url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                credentials {
+                    username = nexusUsername
+                    password = nexusPassword
+                }
+            }
+            if(currentBranch == "master" || currentBranch!!.startsWith("mps")) {
+                maven {
+                    name = "GitHubPackages"
+                    url = uri("https://maven.pkg.github.com/mbeddr/mps-gradle-plugin")
+                    if(project.hasProperty("gpr.token")) {
+                        credentials {
+                            username = project.findProperty("gpr.user") as String?
+                            password = project.findProperty("gpr.token") as String?
+                        }
                     }
                 }
             }

--- a/execute-generators/build.gradle.kts
+++ b/execute-generators/build.gradle.kts
@@ -54,16 +54,3 @@ tasks.withType<KotlinCompile> {
     kotlinOptions.apiVersion = kotlinApiVersion
     kotlinOptions.allWarningsAsErrors = true
 }
-
-publishing {
-    repositories {
-        maven {
-            name = "itemis"
-            url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr")
-            credentials {
-                username = nexusUsername
-                password = nexusPassword
-            }
-        }
-    }
-}

--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -61,17 +61,6 @@ tasks.withType<KotlinCompile> {
 }
 
 publishing {
-    repositories {
-        maven {
-            name = "itemis"
-            url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr")
-            credentials {
-                username = nexusUsername
-                password = nexusPassword
-            }
-        }
-    }
-
     publications {
         create<MavenPublication>("modelcheck") {
             from(components["java"])

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -56,17 +56,6 @@ tasks.withType<KotlinCompile> {
 }
 
 publishing {
-    repositories {
-        maven {
-            name = "itemis"
-            url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr")
-            credentials {
-                username = nexusUsername
-                password = nexusPassword
-            }
-        }
-    }
-
     publications {
         create<MavenPublication>("projectLoader") {
             from(components["java"])


### PR DESCRIPTION
Centralize publishing repositories configuration in the root project so
that all projects use the same repositories.