### PR TITLE
Fix "Multiple publications with coordinates ... are published" error

### DIFF
--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -8,7 +8,6 @@ group = "de.itemis.mps"
 plugins {
     kotlin("jvm")
     `maven-publish`
-    `java-gradle-plugin`
 }
 
 repositories {
@@ -53,6 +52,7 @@ dependencies {
     compileOnly("com.jetbrains:platform-api:$mpsVersion")
     compileOnly("com.jetbrains:extensions:$mpsVersion")
     compileOnly("com.jetbrains:util:$mpsVersion")
+    compileOnly("log4j:log4j:1.2.17")
     implementation(project(":project-loader"))
 }
 

--- a/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
+++ b/modelcheck/gradle/dependency-locks/compileClasspath.lockfile
@@ -20,6 +20,7 @@ com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
+log4j:log4j:1.2.17
 org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm")
     `maven-publish`
-    `java-gradle-plugin`
 }
 
 group = "de.itemis.mps"
@@ -45,6 +44,7 @@ dependencies {
     compileOnly("com.jetbrains:mps-openapi:$mpsVersion")
     compileOnly("com.jetbrains:platform-api:$mpsVersion")
     compileOnly("com.jetbrains:util:$mpsVersion")
+    compileOnly("log4j:log4j:1.2.17")
     testImplementation("junit:junit:4.12")
     testImplementation("org.xmlunit:xmlunit-core:2.6.+")
 }

--- a/project-loader/gradle/dependency-locks/compileClasspath.lockfile
+++ b/project-loader/gradle/dependency-locks/compileClasspath.lockfile
@@ -17,6 +17,7 @@ com.xenomachina:kotlin-argparser:2.0.7
 com.xenomachina:xenocom:0.0.7
 jakarta.activation:jakarta.activation-api:1.2.1
 jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
+log4j:log4j:1.2.17
 org.codehaus.woodstox:stax2-api:4.2.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11


### PR DESCRIPTION
* Modelcheck and project-loader no longer use java-gradle-plugin plugin because they are not Gradle plugins.
* Because of that an explicit dependency on log4j is necessary (it was previously part of Gradle Plugin SDK).