### PR TITLE
generate: support custom mpsLocation

### DIFF
--- a/src/main/kotlin/de/itemis/mps/gradle/generate/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/generate/Plugin.kt
@@ -22,11 +22,10 @@ open class GenerateMpsProjectPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.run {
-
             val extension = extensions.create("generate", GeneratePluginExtensions::class.java)
-            val mpsLocation = extension.mpsLocation ?: File(project.buildDir, "mps")
 
             afterEvaluate {
+                val mpsLocation = extension.mpsLocation ?: File(project.buildDir, "mps")
                 val mpsVersion = extension.getMPSVersion()
 
                 val dep = project.dependencies.create("de.itemis.mps:execute-generators:$mpsVersion+")


### PR DESCRIPTION
Due to a mistake mpsLocation always had the default value because it was
queried too early.