### PR TITLE
jbrdownload: handle new jbr flavours

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ downloadJbr {
 ### Parameters
 * `jbrVersion` - version of the JBR to download. While this supports maven version selectors we highly recomment not
   using wildcards like `*` or `+` in there for reproducible builds. 
+* `distributionType` - optional distribution type for the JBR to use. Will default to `jbr_jcef` if omitted. 
 * `downloadDir` - optional directory where the downloaded JBR is downloaded and extracted to. The plugin defaults to
   `build/jbrDownload`
   

--- a/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
@@ -9,6 +9,7 @@ import java.io.File
 
 open class DownloadJbrConfiguration {
     lateinit var jbrVersion: String
+    var distributionType : String? = null
     var downloadDir: File? = null
 }
 
@@ -21,15 +22,33 @@ open class DownloadJbrProjectPlugin : Plugin<Project> {
             afterEvaluate {
                 val downloadDir = extension.downloadDir ?: File(buildDir, "jbrDownload")
                 val version = extension.jbrVersion
+                // from version 10 on we the jbr distribution type is replaced with jbr_jcef
+                // jbr_jcef is the distribution used to start a normal desktop ide and should include everything 
+                // required for running tests. While a little bit larger than jbr_nomod it should cause the least
+                // surprises when using it as a default. 
+                // see https://github.com/mbeddr/build.publish.jdk/commit/10bbf7d177336179ca189fc8bb4c1262029c69da 
+                val distributionType = if(extension.distributionType == null && 
+                Regex("""11_0_[0-9][^0-9]""").find(version) != null) {
+                    "jbr"
+                } else {
+                    "jbr_jcef"
+                }
+                
+                val cpuArch = when(System.getProperty ("os.arch")) {
+                    "aarch64" -> "aarch64"
+                    "amd64" -> "x64"
+                    else -> throw GradleException("Unsupported CPU Architecture: ${System.getProperty ("os.arch")}! Please open a bug at https://github.com/mbeddr/mps-gradle-plugin with details about your operating system and CPU.")
+
+                }
                 val dependencyString = when {
                     Os.isFamily(Os.FAMILY_MAC) -> {
-                        "com.jetbrains.jdk:jbr:$version:osx-x64@tgz"
+                        "com.jetbrains.jdk:$distributionType:$version:osx-$cpuArch@tgz"
                     }
                     Os.isFamily(Os.FAMILY_WINDOWS) -> {
-                        "com.jetbrains.jdk:jbr:$version:windows-x64@tgz"
+                        "com.jetbrains.jdk:$distributionType:$version:windows-$cpuArch@tgz"
                     }
                     Os.isFamily(Os.FAMILY_UNIX) -> {
-                        "com.jetbrains.jdk:jbr:$version:linux-x64@tgz"
+                        "com.jetbrains.jdk:$distributionType:$version:linux-$cpuArch@tgz"
                     }
                     else -> {
                         throw GradleException("Unsupported platform! Please open a bug at https://github.com/mbeddr/mps-gradle-plugin with details about your operating system.")

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -105,6 +105,46 @@ class JBRDownloadTest {
     }
 
     @Test
+    fun `download new version without distribution type`() {
+        settingsFile.writeText("""
+            rootProject.name = "hello-world"
+        """.trimIndent())
+
+        buildFile.writeText("""
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString() }))
+                }
+            }
+            
+            plugins {
+                id("download-jbr")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                }
+            }
+            
+            downloadJbr {
+                jbrVersion = "11_0_11-b1341.60"
+            }
+        """.trimIndent())
+
+        val result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments("downloadJbr")
+                .withPluginClasspath(cp)
+                .build()
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":downloadJbr")?.outcome)
+        Assert.assertTrue(File(testProjectDir.root, "build/jbrDownload").exists())
+    }
+
+
+    @Test
     fun `executed downloaded java`() {
         settingsFile.writeText("""
             rootProject.name = "hello-world"


### PR DESCRIPTION
From version 11_0_10+ we published the new falvor scheme form JetBrains
into our nexus. That means the default "jbr" artifact is no longer found
for these versions.
The plugin now handles these versions correctly and optionally allows to
specify the flavour in its configuration.

The plugin now also handles aarch64 cpu architecture for new m1 macs.