### PR TITLE
Build: Adapt ghp publication changes to kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,8 @@ version = if (!project.hasProperty("useSnapshot") &&
     "$versionMajor.$versionMinor-SNAPSHOT"
 }
 
+var currentBranch:String? = ""
+currentBranch = de.itemis.mps.gradle.GitBasedVersioning.getGitBranch()
 
 val mpsConfiguration = configurations.create("mps")
 
@@ -103,6 +105,20 @@ publishing {
             credentials {
                 username = nexusUsername
                 password = nexusPassword
+            }
+        }
+    }
+    repositories {
+        if(currentBranch == "master" || currentBranch!!.startsWith("mps")) {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/mbeddr/mps-gradle-plugin")
+                if(project.hasProperty("gpr.token")) {
+                    credentials {
+                        username = project.findProperty("gpr.user") as String
+                        password = project.findProperty("gpr.token") as String
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Takes the addition of a publication to ghp from master in order to make the plugins for MPS 2020.3(.6) to available there.