### PR TITLE
Get checkers to run from CheckerRegistry

### DIFF
--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -27,7 +27,7 @@ val fastXmlJacksonVersion: String by project
 val kotlinApiVersion: String by project
 val kotlinVersion: String by project
 
-val pluginVersion = "3"
+val pluginVersion = "4"
 
 version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity")) {
     // maintenance builds for specific MPS versions should be published without branch prefix, so that they can be

--- a/modelcheck/src/main/kotlin/Main.kt
+++ b/modelcheck/src/main/kotlin/Main.kt
@@ -12,6 +12,7 @@ import de.itemis.mps.gradle.junit.Testsuites
 import de.itemis.mps.gradle.project.loader.Args
 import de.itemis.mps.gradle.project.loader.executeWithProject
 import jetbrains.mps.checkers.*
+import jetbrains.mps.errors.CheckerRegistry
 import jetbrains.mps.errors.MessageStatus
 import jetbrains.mps.errors.item.IssueKindReportItem
 import jetbrains.mps.ide.MPSCoreComponents
@@ -247,20 +248,11 @@ fun modelCheckProject(args: ModelCheckArgs, project: Project): Boolean {
 
     val componentHost = ApplicationManager.getApplication().getComponent(MPSCoreComponents::class.java).platform
 
-    // see ModelCheckerSettings.getSpecificCheckers for details
-    // we do not call into that class because we don't want to load the settings from the user
-    val checkers = listOf(TypesystemChecker(),
-            NonTypesystemChecker(),
-            ConstraintsChecker(componentHost),
-            RefScopeChecker(),
-            TargetConceptChecker2(componentHost),
-            StructureChecker(),
-            UsedLanguagesChecker(),
-            ModelPropertiesChecker(componentHost),
-            UnresolvedReferencesChecker(project),
-            ModuleChecker(),
-            SuppressErrorsChecker())
+    val checkers = componentHost.findComponent(CheckerRegistry::class.java)!!.checkers
 
+    if (logger.isInfoEnabled) {
+        logger.info(checkers.joinToString(prefix = "Found the following checkers in CheckerRegistry: "))
+    }
 
     // We don't use ModelCheckerIssueFinder because it has strange dependency on the ModelCheckerSettings which we
     // want to avoid when running in headless mode


### PR DESCRIPTION
Bump plugin version because this may be a breaking change.

This will allow using custom checkers loaded from a customer-specific plugin.