### PR TITLE
 build: added publication to new nexus itemis cloud

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ repositories {
     mavenCentral()
     maven {
         url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = URI("https://artifacts.itemis.cloud/repository/maven-mps/")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,11 +104,7 @@ allprojects {
         repositories {
             maven {
                 name = "itemisCloud"
-                url = if(project.hasProperty("useSnapshot")) {
-                        uri("https://artifacts.itemis.cloud/repository/maven-mps-snapshots/")
-                      } else { 
-                        uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")
-                      }
+                url = uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")
                 if (project.hasProperty("artifacts.itemis.cloud.user") && project.hasProperty("artifacts.itemis.cloud.pw")) {
                     credentials {
                         username = project.findProperty("artifacts.itemis.cloud.user") as String?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,20 @@ allprojects {
                     password = nexusPassword
                 }
             }
+            maven {
+                name = "itemisCloud"
+                url = if(project.hasProperty("useSnapshot")) {
+                        uri("https://artifacts.itemis.cloud/repository/maven-mps-snapshots/")
+                      } else { 
+                        uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")
+                      }
+                if (project.hasProperty("artifacts.itemis.cloud.user") && project.hasProperty("artifacts.itemis.cloud.pw")) {
+                    credentials {
+                        username = project.findProperty("artifacts.itemis.cloud.user") as String?
+                        password = project.findProperty("artifacts.itemis.cloud.pw") as String?
+                    }
+                }
+            }
             if(currentBranch == "master" || currentBranch!!.startsWith("mps")) {
                 maven {
                     name = "GitHubPackages"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,14 +102,6 @@ allprojects {
     publishing {
         repositories {
             maven {
-                name = "itemis"
-                url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr")
-                credentials {
-                    username = nexusUsername
-                    password = nexusPassword
-                }
-            }
-            maven {
                 name = "itemisCloud"
                 url = if(project.hasProperty("useSnapshot")) {
                         uri("https://artifacts.itemis.cloud/repository/maven-mps-snapshots/")


### PR DESCRIPTION
**Reasons for changes**
- Some of our downstream projects depent on mps20203 artifacts which are not yet published to the itemis cloud.
- In particular  the 2020.3 version of [iets3.os](https://github.com/IETS3/iets3.opensource/tree/maintenance/mps20203) is depending on `de.itemis.mps:mps-gradle-plugin:1.2.175.cc60dc8`
-  that artifact needs to be available under https://artifacts.itemis.cloud/repository/maven-mps/

This PR is adding the missing publication part to the new itemis cloud.
