### PR TITLE
Remove old project.itemis nexus dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ being set and no value set for `mpsConfig`. If you set `mpsVersion` but also set
 will take precedence over `mpsVersion` and the plugin will resolve that configuration into `mpsLocation`. 
 
 `mpsVersion` needs to be set to the exact MPS version your custom distribution is based on e.g. if you build a
-RCP with MPS 2020.3.6 you need to set this property to `2020.3.6`. `mpsLocation` needs to point to the location
+RCP with MPS 2020.3.4 you need to set this property to `2020.3.4`. `mpsLocation` needs to point to the location
 where you extracted your custom MPS distribution into e.g. `$buildDir/myAwesomeMPS` if you extracted into that location. 
 
 Each of the plugins creates a `resolveMpsFor<name>` task in the build. When `mpsVersion` and `mpsLocation` are set
@@ -443,7 +443,7 @@ task downloadAndExtractCustomMPS() {
 
 modelcheck {
     mpsLocation.set(myCustomLocation)
-    mpsVersion.set("2020.3.6")
+    mpsVersion.set("2020.3.4")
     projectLocation.set(file("$rootDir/mps-prj"))
     modules.set(["my.solution.with.errors"])
     junitFile.set(file("$buildDir/TEST-modelcheck-results.xml"))

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ repositories {
 }
 
 downloadJbr {
-    jbrVersion.set("11_0_10-b1341.41")
+    jbrVersion.set("11_0_10-b1145.96")
 }
 ```
 
@@ -401,7 +401,7 @@ repositories {
 }
 
 downloadJbr {
-    jbrVersion.set('11_0_10-b1341.41')
+    jbrVersion.set('11_0_10-b1145.96')
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ repositories {
 }
 
 downloadJbr {
-    jbrVersion.set("11_0_6-b520.66")
+    jbrVersion.set("11_0_10-b1145.96")
 }
 ```
 
@@ -401,7 +401,7 @@ repositories {
 }
 
 downloadJbr {
-    jbrVersion.set('11_0_6-b520.66')
+    jbrVersion.set('11_0_10-b1145.96')
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ repositories {
 }
 
 downloadJbr {
-    jbrVersion.set("11_0_10-b1145.96")
+    jbrVersion.set("11_0_10-b1341.41")
 }
 ```
 
@@ -401,7 +401,7 @@ repositories {
 }
 
 downloadJbr {
-    jbrVersion.set('11_0_10-b1145.96')
+    jbrVersion.set('11_0_10-b1341.41')
 }
 ```
 
@@ -426,7 +426,7 @@ being set and no value set for `mpsConfig`. If you set `mpsVersion` but also set
 will take precedence over `mpsVersion` and the plugin will resolve that configuration into `mpsLocation`. 
 
 `mpsVersion` needs to be set to the exact MPS version your custom distribution is based on e.g. if you build a
-RCP with MPS 2020.3.3 you need to set this property to `2020.3.3`. `mpsLocation` needs to point to the location
+RCP with MPS 2020.3.6 you need to set this property to `2020.3.6`. `mpsLocation` needs to point to the location
 where you extracted your custom MPS distribution into e.g. `$buildDir/myAwesomeMPS` if you extracted into that location. 
 
 Each of the plugins creates a `resolveMpsFor<name>` task in the build. When `mpsVersion` and `mpsLocation` are set
@@ -443,7 +443,7 @@ task downloadAndExtractCustomMPS() {
 
 modelcheck {
     mpsLocation.set(myCustomLocation)
-    mpsVersion.set("2020.3.3")
+    mpsVersion.set("2020.3.6")
     projectLocation.set(file("$rootDir/mps-prj"))
     modules.set(["my.solution.with.errors"])
     junitFile.set(file("$buildDir/TEST-modelcheck-results.xml"))

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following `buildscript` block to your build script:
 ```
 buildscript {
     repositories {
-        maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
+        maven { url 'https://artifacts.itemis.cloud/repository/maven-mps' }
         mavenCentral()
     }
 
@@ -362,7 +362,7 @@ way of doing this with a gradle plugin.
 
 The download-jbr plugin will add new dependencies and a task to your build. It will add a dependency to `com.jetbrains.jdk:jbr`
 to your build, you need to make sure that it is available in your dependency repositories. The itemis maven repository at 
-`https://projects.itemis.de/nexus/content/repositories/mbeddr` provides this dependency, but you can create your own with
+`https://artifacts.itemis.cloud/repository/maven-mps` provides this dependency, but you can create your own with
 the scripts located in mbeddr/build.publish.jdk 
 
 For easy consumption and incremental build support the plugin creates a task `downloadJbr` which exposes the location of 
@@ -381,7 +381,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
     }
 }
 
@@ -396,7 +396,7 @@ apply plugin: 'download-jbr'
 ...
 
 repositories {
-    maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
+    maven { url 'https://artifacts.itemis.cloud/repository/maven-mps' }
     mavenCentral()
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ val mpsConfiguration = configurations.create("mps")
 repositories {
     mavenCentral()
     maven {
-        url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ val nexusUsername: String? by project
 val nexusPassword: String? by project
 
 val kotlinArgParserVersion by extra { "2.0.7" }
-val mpsVersion by extra { "2020.3.4" }
+val mpsVersion by extra { "2020.3.6" }
 //this version needs to align with the version shiped with MPS found in the /lib folder otherwise, runtime problems will
 //surface because mismatching jars on the classpath.
 val fastXmlJacksonVersion by extra { "2.11.+" }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,6 @@ val versionMinor = 0
 
 group = "de.itemis.mps"
 
-
-val nexusUsername: String? by project
-val nexusPassword: String? by project
-
 val kotlinArgParserVersion by extra { "2.0.7" }
 val mpsVersion by extra { "2020.3.6" }
 //this version needs to align with the version shiped with MPS found in the /lib folder otherwise, runtime problems will
@@ -101,14 +97,6 @@ allprojects {
     apply<MavenPublishPlugin>()
     publishing {
         repositories {
-            maven {
-                name = "itemis"
-                url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr")
-                credentials {
-                    username = nexusUsername
-                    password = nexusPassword
-                }
-            }
             maven {
                 name = "itemisCloud"
                 url = uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,11 +111,7 @@ allprojects {
             }
             maven {
                 name = "itemisCloud"
-                url = if(project.hasProperty("useSnapshot")) {
-                        uri("https://artifacts.itemis.cloud/repository/maven-mps-snapshots/")
-                      } else { 
-                        uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")
-                      }
+                url = uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")
                 if (project.hasProperty("artifacts.itemis.cloud.user") && project.hasProperty("artifacts.itemis.cloud.pw")) {
                     credentials {
                         username = project.findProperty("artifacts.itemis.cloud.user") as String?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ val versionMinor = 0
 group = "de.itemis.mps"
 
 val kotlinArgParserVersion by extra { "2.0.7" }
-val mpsVersion by extra { "2020.3.6" }
+val mpsVersion by extra { "2020.3.4" }
 //this version needs to align with the version shiped with MPS found in the /lib folder otherwise, runtime problems will
 //surface because mismatching jars on the classpath.
 val fastXmlJacksonVersion by extra { "2.11.+" }

--- a/execute-generators/build.gradle.kts
+++ b/execute-generators/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
     }
 }
 

--- a/execute-generators/build.gradle.kts
+++ b/execute-generators/build.gradle.kts
@@ -16,9 +16,6 @@ repositories {
     }
 }
 
-val nexusUsername: String? by project
-val nexusPassword: String? by project
-
 val kotlinArgParserVersion: String by project
 val mpsVersion: String by project
 

--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
     }
 }
 

--- a/modelcheck/build.gradle.kts
+++ b/modelcheck/build.gradle.kts
@@ -17,9 +17,6 @@ repositories {
     }
 }
 
-val nexusUsername: String? by project
-val nexusPassword: String? by project
-
 val kotlinArgParserVersion: String by project
 val mpsVersion: String by project
 val fastXmlJacksonVersion: String by project

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -13,8 +13,6 @@ val kotlinArgParserVersion: String by project
 val kotlinApiVersion: String by project
 val kotlinVersion: String by project
 
-val nexusUsername: String? by project
-val nexusPassword: String? by project
 val fastXmlJacksonVersion: String by project
 
 val pluginVersion = "1"

--- a/project-loader/build.gradle.kts
+++ b/project-loader/build.gradle.kts
@@ -30,7 +30,7 @@ version = if (project.hasProperty("forceCI") || project.hasProperty("teamcity"))
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = uri("https://artifacts.itemis.cloud/repository/maven-mps")
     }
 }
 

--- a/src/test/kotlin/test/de/itemis/mps/gradle/GenerateModelsTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/GenerateModelsTest.kt
@@ -59,7 +59,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             generate {
@@ -154,7 +154,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             generate {
@@ -203,7 +203,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             generate {
@@ -251,7 +251,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             generate {
@@ -297,7 +297,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             generate {

--- a/src/test/kotlin/test/de/itemis/mps/gradle/GenerateModelsTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/GenerateModelsTest.kt
@@ -59,7 +59,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             generate {
@@ -154,7 +154,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             generate {
@@ -203,7 +203,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             generate {
@@ -251,7 +251,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             generate {
@@ -297,7 +297,7 @@ class GenerateModelsTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             generate {

--- a/src/test/kotlin/test/de/itemis/mps/gradle/GenerateModelsTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/GenerateModelsTest.kt
@@ -52,7 +52,7 @@ class GenerateModelsTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -100,7 +100,7 @@ class GenerateModelsTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -147,7 +147,7 @@ class GenerateModelsTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -196,7 +196,7 @@ class GenerateModelsTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -244,7 +244,7 @@ class GenerateModelsTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -290,7 +290,7 @@ class GenerateModelsTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -27,7 +27,7 @@ class JBRDownloadTest {
     }
 
     @Test
-    fun `download with download dir`() {
+    fun `download with download dir and distribution type`() {
         settingsFile.writeText("""
             rootProject.name = "hello-world"
         """.trimIndent())
@@ -53,6 +53,7 @@ class JBRDownloadTest {
             
             downloadJbr {
                 jbrVersion.set("11_0_10-b1145.96")
+                distributionType.set("jbr_nomod")
                 downloadDir.set(file("jbrdl"))
             }
         """.trimIndent())
@@ -66,7 +67,7 @@ class JBRDownloadTest {
         Assert.assertTrue(File(testProjectDir.root, "jbrdl").exists())
     }
     @Test
-    fun `download without download dir`() {
+    fun `download without download dir and distribution type`() {
         settingsFile.writeText("""
             rootProject.name = "hello-world"
         """.trimIndent())
@@ -92,6 +93,7 @@ class JBRDownloadTest {
             
             downloadJbr {
                 jbrVersion.set("11_0_10-b1145.96")
+                distributionType.set("jbr_nomod")
             }
         """.trimIndent())
 

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -53,7 +53,7 @@ class JBRDownloadTest {
             
             downloadJbr {
                 jbrVersion.set("11_0_10-b1145.96")
-                distributionType.set("jbr_nomod")
+                distributionType.set("jbr")
                 downloadDir.set(file("jbrdl"))
             }
         """.trimIndent())
@@ -93,7 +93,7 @@ class JBRDownloadTest {
             
             downloadJbr {
                 jbrVersion.set("11_0_10-b1145.96")
-                distributionType.set("jbr_nomod")
+                distributionType.set("jbr")
             }
         """.trimIndent())
 

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -52,7 +52,7 @@ class JBRDownloadTest {
             }
             
             downloadJbr {
-                jbrVersion.set("11_0_6-b520.66")
+                jbrVersion.set("11_0_10-b1341.41")
                 downloadDir.set(file("jbrdl"))
             }
         """.trimIndent())
@@ -91,7 +91,7 @@ class JBRDownloadTest {
             }
             
             downloadJbr {
-                jbrVersion.set("11_0_6-b520.66")
+                jbrVersion.set("11_0_10-b1341.41")
             }
         """.trimIndent())
 

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -136,7 +136,7 @@ class JBRDownloadTest {
             }
             
             downloadJbr {
-                jbrVersion.set("11_0_11-b1341.60")
+                jbrVersion.set("11_0_10-b1145.96")
             }
         """.trimIndent())
 
@@ -150,7 +150,7 @@ class JBRDownloadTest {
         Assert.assertTrue(jbrDownloadDir.exists())
         val jbrReleaseFile = File(jbrDownloadDir, "jbr/release")
         Assert.assertTrue(jbrReleaseFile.exists())
-        Assert.assertTrue("downloaded jbr doesn't contain expected distro", jbrReleaseFile.readText().contains("1341.60-jcef"))
+        Assert.assertTrue("downloaded jbr doesn't contain expected distro", jbrReleaseFile.readText().contains("1145.96-jcef"))
     }
 
     @Test
@@ -179,7 +179,7 @@ class JBRDownloadTest {
             }
             
             downloadJbr {
-                jbrVersion.set("11_0_11-b1341.60")
+                jbrVersion.set("11_0_10-b1145.96")
                 distributionType.set("jbr_nomod")
             }
         """.trimIndent())
@@ -194,7 +194,7 @@ class JBRDownloadTest {
         Assert.assertTrue(jbrDownloadDir.exists())
         val jbrReleaseFile = File(jbrDownloadDir, "jbr/release")
         Assert.assertTrue(jbrReleaseFile.exists())
-        Assert.assertTrue("downloaded jbr doesn't contain expected distro", jbrReleaseFile.readText().contains("1341.60-nomod"))
+        Assert.assertTrue("downloaded jbr doesn't contain expected distro", jbrReleaseFile.readText().contains("1145.96-nomod"))
     }
 
     @Test

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -47,7 +47,7 @@ class JBRDownloadTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -86,7 +86,7 @@ class JBRDownloadTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -125,7 +125,7 @@ class JBRDownloadTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -168,7 +168,7 @@ class JBRDownloadTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -212,7 +212,7 @@ class JBRDownloadTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -27,7 +27,7 @@ class JBRDownloadTest {
     }
 
     @Test
-    fun `download with download dir and distribution type`() {
+    fun `download with download dir`() {
         settingsFile.writeText("""
             rootProject.name = "hello-world"
         """.trimIndent())
@@ -53,7 +53,6 @@ class JBRDownloadTest {
             
             downloadJbr {
                 jbrVersion.set("11_0_10-b1145.96")
-                distributionType.set("jbr")
                 downloadDir.set(file("jbrdl"))
             }
         """.trimIndent())
@@ -103,7 +102,12 @@ class JBRDownloadTest {
                 .withPluginClasspath(cp)
                 .build()
         Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":downloadJbr")?.outcome)
-        Assert.assertTrue(File(testProjectDir.root, "build/jbrDownload").exists())
+        val jbrDownloadDir = File(testProjectDir.root, "build/jbrDownload")
+        Assert.assertTrue(jbrDownloadDir.exists())
+        val jbrReleaseFile = File(jbrDownloadDir, "jbr/release")
+        Assert.assertTrue(jbrReleaseFile.exists())
+        // distro type "jbr" contains jfx prefix
+        Assert.assertTrue("downloaded jbr doesn't contain expected distro", jbrReleaseFile.readText().contains("1145.96-jfx_jcef"))
     }
 
     @Test

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -52,7 +52,7 @@ class JBRDownloadTest {
             }
             
             downloadJbr {
-                jbrVersion.set("11_0_10-b1341.41")
+                jbrVersion.set("11_0_10-b1145.96")
                 downloadDir.set(file("jbrdl"))
             }
         """.trimIndent())
@@ -91,7 +91,7 @@ class JBRDownloadTest {
             }
             
             downloadJbr {
-                jbrVersion.set("11_0_10-b1341.41")
+                jbrVersion.set("11_0_10-b1145.96")
             }
         """.trimIndent())
 

--- a/src/test/kotlin/test/de/itemis/mps/gradle/ModelCheckTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/ModelCheckTest.kt
@@ -56,7 +56,7 @@ class ModelCheckTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -106,7 +106,7 @@ class ModelCheckTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -156,7 +156,7 @@ class ModelCheckTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -206,7 +206,7 @@ class ModelCheckTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -255,7 +255,7 @@ class ModelCheckTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             
@@ -302,7 +302,7 @@ class ModelCheckTest {
             repositories {
                 mavenCentral()
                 maven {
-                    url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
                 }
             }
             

--- a/src/test/kotlin/test/de/itemis/mps/gradle/ModelCheckTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/ModelCheckTest.kt
@@ -63,7 +63,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             modelcheck {
@@ -163,7 +163,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             modelcheck {
@@ -213,7 +213,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             modelcheck {
@@ -262,7 +262,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             modelcheck {
@@ -309,7 +309,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.3")
+                mps("com.jetbrains:mps:2020.3.6")
             }
             
             modelcheck {

--- a/src/test/kotlin/test/de/itemis/mps/gradle/ModelCheckTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/ModelCheckTest.kt
@@ -63,7 +63,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             modelcheck {
@@ -163,7 +163,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             modelcheck {
@@ -213,7 +213,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             modelcheck {
@@ -262,7 +262,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             modelcheck {
@@ -309,7 +309,7 @@ class ModelCheckTest {
             val mps = configurations.create("mps")
             
             dependencies {
-                mps("com.jetbrains:mps:2020.3.6")
+                mps("com.jetbrains:mps:2020.3.4")
             }
             
             modelcheck {

--- a/test/generate-build-solution/build.gradle.kts
+++ b/test/generate-build-solution/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = java.net.URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = java.net.URI("https://artifacts.itemis.cloud/repository/maven-mps")
     }
 }
 

--- a/test/generate-simple/build.gradle.kts
+++ b/test/generate-simple/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = java.net.URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = java.net.URI("https://artifacts.itemis.cloud/repository/maven-mps")
     }
 }
 

--- a/test/modelcheck/build.gradle.kts
+++ b/test/modelcheck/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 repositories {
     maven {
-        url = URI("https://projects.itemis.de/nexus/content/repositories/mbeddr")
+        url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
     }
     mavenLocal()
     mavenCentral()


### PR DESCRIPTION
This PR removes the dependency to our old NEXUS and switches to the new one: _artifacts.itemis.cloud_
Under this scope some minor version updates were done to match existing artifact versions on the new nexus.

- JDK/JBR version updated to 11_0_10-b1341.41 in tests
- ~Updated MPS version to 2020.3.6 in build and tests~
- Removed snapshot publication and publication to old nexus

Those changes should also fix #103