### PR TITLE
Fix usage of the distributionType property in downloadJbr plugin

### DIFF
--- a/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
@@ -38,12 +38,14 @@ open class DownloadJbrProjectPlugin : Plugin<Project> {
                 // required for running tests. While a little bit larger than jbr_nomod it should cause the least
                 // surprises when using it as a default.
                 // see https://github.com/mbeddr/build.publish.jdk/commit/10bbf7d177336179ca189fc8bb4c1262029c69da
-                val distributionTypeVal = if(!extension.distributionType.isPresent &&
-                Regex("""11_0_[0-9][^0-9]""").find(version) != null) {
-                    "jbr"
-                } else {
-                    "jbr_jcef"
-                }
+                val distributionTypeVal = extension.distributionType.getOrElse(
+                    // default distribution type
+                    if (Regex("""11_0_[0-9][^0-9]""").find(version) != null) {
+                        "jbr"
+                    } else {
+                        "jbr_jcef"
+                    }
+                )
 
                 val cpuArch = when(System.getProperty ("os.arch")) {
                     "aarch64" -> "aarch64"

--- a/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/JBRDownloadTest.kt
@@ -36,7 +36,7 @@ class JBRDownloadTest {
             import java.net.URI
             buildscript {
                 dependencies {
-                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString() }))
+                    "classpath"(files(${cp.joinToString { """"${it.invariantSeparatorsPath}"""" }}))
                 }
             }
             
@@ -75,7 +75,7 @@ class JBRDownloadTest {
             import java.net.URI
             buildscript {
                 dependencies {
-                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString() }))
+                    "classpath"(files(${cp.joinToString { """"${it.invariantSeparatorsPath}"""" }}))
                 }
             }
             
@@ -114,7 +114,7 @@ class JBRDownloadTest {
             import java.net.URI
             buildscript {
                 dependencies {
-                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString() }))
+                    "classpath"(files(${cp.joinToString { """"${it.invariantSeparatorsPath}"""" }}))
                 }
             }
             
@@ -140,7 +140,11 @@ class JBRDownloadTest {
                 .withPluginClasspath(cp)
                 .build()
         Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":downloadJbr")?.outcome)
-        Assert.assertTrue(File(testProjectDir.root, "build/jbrDownload").exists())
+        val jbrDownloadDir = File(testProjectDir.root, "build/jbrDownload")
+        Assert.assertTrue(jbrDownloadDir.exists())
+        val jbrReleaseFile = File(jbrDownloadDir, "jbr/release")
+        Assert.assertTrue(jbrReleaseFile.exists())
+        Assert.assertTrue("downloaded jbr doesn't contain expected distro", jbrReleaseFile.readText().contains("1341.60-jcef"))
     }
 
     @Test
@@ -153,7 +157,7 @@ class JBRDownloadTest {
             import java.net.URI
             buildscript {
                 dependencies {
-                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString() }))
+                    "classpath"(files(${cp.joinToString { """"${it.invariantSeparatorsPath}"""" }}))
                 }
             }
             
@@ -180,7 +184,11 @@ class JBRDownloadTest {
             .withPluginClasspath(cp)
             .build()
         Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":downloadJbr")?.outcome)
-        Assert.assertTrue(File(testProjectDir.root, "build/jbrDownload").exists())
+        val jbrDownloadDir = File(testProjectDir.root, "build/jbrDownload")
+        Assert.assertTrue(jbrDownloadDir.exists())
+        val jbrReleaseFile = File(jbrDownloadDir, "jbr/release")
+        Assert.assertTrue(jbrReleaseFile.exists())
+        Assert.assertTrue("downloaded jbr doesn't contain expected distro", jbrReleaseFile.readText().contains("1341.60-nomod"))
     }
 
     @Test
@@ -193,7 +201,7 @@ class JBRDownloadTest {
             import java.net.URI
             buildscript {
                 dependencies {
-                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString() }))
+                    "classpath"(files(${cp.joinToString { """"${it.invariantSeparatorsPath}"""" }}))
                 }
             }
             


### PR DESCRIPTION
`distributionType`  property of the downloadJbr plugin was not properly evaluated in case it was provided by the user. This PR fixes that issue.