### PR TITLE
Add support for running migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Parameters:
 * `mpsConfig` - the configuration used to resolve MPS. Currently only vanilla MPS is supported and no custom RCPs.
   Custom plugins are supported via the `pluginLocation` parameter.
 * `mpsLocation` - optional location where to place the MPS files.
-* `mpsVersion` - optional if you use a [custom distribution](#Custom MPS Distribution) of MPS
+* `mpsVersion` - optional if you use a [custom distribution](#custom-mps-distribution) of MPS
 * `javaExec` - optional `java` executable to use.
 * `pluginLocation` - location where to load the plugins from. Structure needs to be a flat folder structure similar to the
   `plugins` directory inside of the MPS installation.
@@ -299,7 +299,7 @@ Parameters:
 * `mpsConfig` - the configuration used to resolve MPS. Currently only vanilla MPS is supported and no custom RCPs.
   Custom plugins are supported via the `pluginLocation` parameter.
 * `mpsLocation` - optional location where to place the MPS files.
-* `mpsVersion` - optional if you use a [custom distribution](#Custom MPS Distribution) of MPS
+* `mpsVersion` - optional if you use a [custom distribution](#custom-mps-distribution) of MPS
 * `javaExec` - optional `java` executable to use.
 * `pluginLocation` - location where to load the plugins from. Structure needs to be a flat folder structure similar to the
   `plugins` directory inside of the MPS installation.
@@ -330,7 +330,40 @@ Parameters:
 * `maxHeap` - maximum heap size setting for the JVM that executes the modelchecker. This is useful to limit the heap usage
   in scenarios like containerized build agents where the OS reported memory limit is not the maximum
   to be consumed by the container. The value is a string understood by the JVM command line argument `-Xmx` e.g. `3G` or `512M
-  
+
+
+## Run migrations
+
+Run all pending migrations in the project.
+
+### Usage
+
+A minimal build script to check all models in a MPS project with no external plugins would look like this:
+
+```
+apply plugin: 'run-migrations"'
+
+configurations {
+    mps
+}
+
+dependencies {
+    mps "com.jetbrains:mps:$mpsVersion"
+}
+
+runMigrations {
+    projectLocation.set(new File("./mps-prj"))
+    mpsConfig.set(configurations.mps)
+}
+```
+
+Parameters:
+* `mpsConfig` - the configuration used to resolve MPS.
+* `mpsLocation` - optional location where to place the MPS files.
+* `mpsVersion` - optional if you use a [custom distribution](#custom-mps-distribution) of MPS.
+* `projectLocation` - optional location of the project that should be migrated.
+* `force` - ignores the marker files for projects which allow pending migrations, migrate them anyway (supported in 2021.3.0 and higher)
+
 ### Additional Plugins 
 
 By default only the minimum required set of plugins are loaded. This includes base language and some utilities like the

--- a/README.md
+++ b/README.md
@@ -358,11 +358,13 @@ runMigrations {
 ```
 
 Parameters:
-* `mpsConfig` - the configuration used to resolve MPS.
-* `mpsLocation` - optional location where to place the MPS files.
-* `mpsVersion` - optional if you use a [custom distribution](#custom-mps-distribution) of MPS.
-* `projectLocation` - optional location of the project that should be migrated.
+* `mpsConfig` - configuration used to resolve MPS.
+* `mpsLocation` - location where to place the MPS files.
+* `mpsVersion` - if you use a [custom distribution](#custom-mps-distribution) of MPS.
+* `projectLocation` - location of the project that should be migrated.
 * `force` - ignores the marker files for projects which allow pending migrations, migrate them anyway (supported in 2021.3.0 and higher)
+
+At least `mpsConfig` or `mpsLocation` + `mpsVersion` must be set.
 
 ### Additional Plugins 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,7 @@ dependencyLocking {
 dependencies {
     implementation(localGroovy())
     implementation(kotlin("stdlib", version = kotlinVersion))
+    implementation("net.swiftzer.semver:semver:1.1.2")
     testImplementation("junit:junit:4.13.2")
 }
 
@@ -72,6 +73,10 @@ gradlePlugin {
         register("modelcheck") {
             id = "modelcheck"
             implementationClass = "de.itemis.mps.gradle.modelcheck.ModelcheckMpsProjectPlugin"
+        }
+        register("migrations-executor") {
+            id = "run-migrations"
+            implementationClass = "de.itemis.mps.gradle.runmigrations.RunMigrationsMpsProjectPlugin"
         }
         register("download-jbr") {
             id = "download-jbr"

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -2,6 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 junit:junit:4.13.2=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
+net.swiftzer.semver:semver:1.1.2=compileClasspath,implementationDependenciesMetadata,runtimeClasspath,testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 org.hamcrest:hamcrest-core:1.3=testCompileClasspath,testImplementationDependenciesMetadata,testRuntimeClasspath
 org.jetbrains.intellij.deps:trove4j:1.0.20181211=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath
 org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.31=kotlinCompilerClasspath,kotlinKlibCommonizerClasspath

--- a/src/main/kotlin/de/itemis/mps/gradle/runmigrations/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/runmigrations/Plugin.kt
@@ -21,6 +21,8 @@ open class RunMigrationsMpsProjectPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.run {
             val extension = extensions.create("runMigrations", MigrationExecutorPluginExtensions::class.java)
+            tasks.register("runMigrations")
+            
             afterEvaluate {
                 val mpsLocation = extension.mpsLocation.convention{ File(project.buildDir, "mps") }.map { it.asFile }.get()
                 val projectLocation = extension.projectLocation.getOrElse { throw GradleException("No project path set") }
@@ -44,7 +46,7 @@ open class RunMigrationsMpsProjectPlugin : Plugin<Project> {
                     tasks.create("resolveMpsForMigrations")
                 }
                 
-                tasks.register("runMigrations") {
+                tasks.named("runMigrations") {
                     dependsOn(resolveMps)
                     doLast {
                         ant.withGroovyBuilder { 

--- a/src/main/kotlin/de/itemis/mps/gradle/runmigrations/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/runmigrations/Plugin.kt
@@ -1,0 +1,83 @@
+package de.itemis.mps.gradle.runmigrations
+
+import de.itemis.mps.gradle.*
+import net.swiftzer.semver.SemVer
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Copy
+import org.gradle.kotlin.dsl.withGroovyBuilder
+import java.io.File
+import javax.inject.Inject
+
+open class MigrationExecutorPluginExtensions @Inject constructor(of: ObjectFactory, project: Project) : BasePluginExtensions(of, project) {
+    val force: Property<Boolean> = of.property(Boolean::class.java).convention(false)
+}
+@Suppress("unused")
+open class RunMigrationsMpsProjectPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.run {
+            val extension = extensions.create("runMigrations", MigrationExecutorPluginExtensions::class.java)
+            afterEvaluate {
+                val mpsLocation = extension.mpsLocation.convention{ File(project.buildDir, "mps") }.map { it.asFile }.get()
+                val projectLocation = extension.projectLocation.getOrElse { throw GradleException("No project path set") }
+                if(!file(projectLocation).exists()) {
+                    throw GradleException("The path to the project doesn't exist:$projectLocation")
+                }
+                val forceMigration = extension.force
+                
+                val mpsVersion = extension.getMPSVersion()
+                val parsedMPSVersion = SemVer.parse(mpsVersion)
+                if(forceMigration.getOrElse(false) && (parsedMPSVersion.major < 2021 || (parsedMPSVersion.major == 2021 && parsedMPSVersion.minor < 3))) {
+                    throw GradleException("The force migration flag is only supported for 2021.3.0 and higher.")
+                }
+                
+                val resolveMps: Task = if (extension.mpsConfig.isPresent) {
+                    tasks.create("resolveMpsForMigrations", Copy::class.java) {
+                        from({extension.mpsConfig.get().resolve().map { zipTree(it) }})
+                        into(mpsLocation)
+                    }
+                } else {
+                    tasks.create("resolveMpsForMigrations")
+                }
+                
+                tasks.register("runMigrations") {
+                    dependsOn(resolveMps)
+                    doLast {
+                        ant.withGroovyBuilder { 
+                            "path"("id" to "path.mps.ant.path",) {
+                                // The different MPS versions need different jars. Let's just keep it simple and include all jars.
+                                "fileset"("dir" to  "$mpsLocation/lib", "includes" to "**/*.jar")
+                            }
+                            "taskdef"("resource" to "jetbrains/mps/build/ant/antlib.xml", "classpathref" to "path.mps.ant.path")
+                        }
+                        if(forceMigration.getOrElse(false)) {
+                            ant.withGroovyBuilder {
+                                "migrate"("project" to projectLocation, "mpsHome" to mpsLocation, "force" to true) {
+                                    "macro"("name" to "mps_home", "path" to mpsLocation)
+                                    "jvmargs"() {
+                                        "arg"("value" to "-Didea.log.config.file=log.xml")
+                                        "arg"("value" to "-ea")
+                                    }
+                                }
+                            }
+                        } else {
+                            ant.withGroovyBuilder {
+                                "migrate"("project" to projectLocation, "mpsHome" to mpsLocation) {
+                                    "macro"("name" to "mps_home", "path" to mpsLocation)
+                                    "jvmargs"() {
+                                        "arg"("value" to "-Didea.log.config.file=log.xml")
+                                        "arg"("value" to "-ea")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/test/de/itemis/mps/gradle/RunMigrationsTest.kt
+++ b/src/test/kotlin/test/de/itemis/mps/gradle/RunMigrationsTest.kt
@@ -1,0 +1,185 @@
+package test.de.itemis.mps.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class RunMigrationsTest {
+    @Rule
+    @JvmField
+    val testProjectDir: TemporaryFolder = TemporaryFolder()
+    private lateinit var settingsFile: File
+    private lateinit var buildFile: File
+    private lateinit var cp: List<File>
+    private lateinit var mpsTestPrjLocation: File
+    
+    private fun commonGradleScriptPart():String {
+        return """
+            import java.net.URI
+            buildscript {
+                dependencies {
+                    "classpath"(files(${cp.map { """"${it.invariantSeparatorsPath}"""" }.joinToString()}))
+                }
+            }
+            
+            plugins {
+                id("run-migrations")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven {
+                    url = URI("https://artifacts.itemis.cloud/repository/maven-mps")
+                }
+            }
+            
+             val mps = configurations.create("mps")
+        """.trimIndent()
+    }
+
+    @Before
+    fun setup() {
+        settingsFile = testProjectDir.newFile("settings.gradle.kts")
+        settingsFile.writeText(
+            """
+            rootProject.name = "hello-world"
+        """.trimIndent()
+        )
+        buildFile = testProjectDir.newFile("build.gradle.kts")
+        cp = javaClass.classLoader.getResource(
+            "plugin-classpath.txt"
+        )!!.readText().lines().map { File(it) }
+        mpsTestPrjLocation = testProjectDir.newFolder("mps-prj")
+        ProjectHelper().extractTestProject(mpsTestPrjLocation)
+    }
+    
+    @Test
+    fun `check run migrations works with MPS 2020_3`() {
+        buildFile.writeText(
+            """
+            ${commonGradleScriptPart()}
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.4")
+            }
+            
+            runMigrations {
+                projectLocation.set(file("${mpsTestPrjLocation.toPath()}"))
+                mpsConfig.set(mps)
+            }
+        """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("runMigrations")
+            .withPluginClasspath(cp)
+            .build()
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":runMigrations")?.outcome)
+    }
+
+    @Test
+    fun `check run migrations fails with MPS 2020_3 with force set to true`() {
+        buildFile.writeText(
+            """
+            ${commonGradleScriptPart()}
+            
+            dependencies {
+                mps("com.jetbrains:mps:2020.3.4")
+            }
+            
+            runMigrations {
+                projectLocation.set(file("${mpsTestPrjLocation.toPath()}"))
+                mpsConfig.set(mps)
+                force.set(true)
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("runMigrations")
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+
+
+    @Test
+    fun `check run migrations works with MPS 2021_3 with force flag`() {
+        buildFile.writeText(
+            """
+            ${commonGradleScriptPart()}
+            
+            dependencies {
+                mps("com.jetbrains:mps:2021.3.2")
+            }
+            
+            runMigrations {
+                projectLocation.set(file("${mpsTestPrjLocation.toPath()}"))
+                mpsConfig.set(mps)
+                force.set(true)
+            }
+        """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("runMigrations")
+            .withPluginClasspath(cp)
+            .build()
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":runMigrations")?.outcome)
+    }
+
+    @Test
+    fun `check run migrations fails with invalid project path`() {
+        buildFile.writeText(
+            """
+            ${commonGradleScriptPart()}
+            
+            dependencies {
+                mps("com.jetbrains:mps:2021.3.2")
+            }
+            
+            runMigrations {
+                projectLocation.set(file("not_existing"))
+                mpsConfig.set(mps)
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("runMigrations")
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+
+    @Test
+    fun `check run migrations fails with invalid mps path`() {
+        buildFile.writeText(
+            """
+            ${commonGradleScriptPart()}
+            
+            dependencies {
+                mps("com.jetbrains:mps:2021.3.2")
+            }
+            
+            runMigrations {
+                projectLocation.set(file("${mpsTestPrjLocation.toPath()}"))
+                mpsLocation.set(file("not_existing"))
+            }
+        """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("runMigrations")
+            .withPluginClasspath(cp)
+            .buildAndFail()
+    }
+}


### PR DESCRIPTION
The new `run-migrations` plugin works similar to the modelcheck plugin:

```
apply plugin: 'run-migrations'

configurations {
    mps
}

dependencies {
    mps "com.jetbrains:mps:$mpsVersion"
}

runMigrations {
    projectLocation.set(new File("./mps-prj"))
    mpsConfig.set(configurations.mps)
}
```

The plugin should work with any MPS version as all jars are included as dependencies. It uses the `migrate` Ant task directly. There is a `makeDistribModules` flag that I haven't implemented because I am not sure if we need it.

One of the classes that this task uses is [MPSLoadTask](https://github.com/JetBrains/MPS/blob/master/core/tool/ant/source_gen/jetbrains/mps/build/ant/MpsLoadTask.java) which might support some more arguments as well as the [MigrateTaskProperties](https://github.com/JetBrains/MPS/blob/master/core/tool/common/source_gen/jetbrains/mps/tool/common/MigrateTaskProperties.java) in newer MPS versions which declares some attributes. Please let me know if we require any of those properties and list their Ant attribute names.
The only examples for invoking this Ant task can be found in [mpsMigrationTest.xml](https://github.com/JetBrains/MPS/blob/master/build/tests/mpsMigrationTest.xml) and [mpsSmartRefAttrMigration.xml](https://github.com/JetBrains/MPS/blob/master/build/tests/mpsSmartRefAttrMigration.xml).

One additional question: is there a trick to save part of a [Groovy builder](https://docs.gradle.org/current/userguide/kotlin_dsl.html#the_kotlin_dsl_groovy_builder) into a variable in a Gradle script? I want to write code like this:

```
val ref = "test"("123")

ant.withGroovyBuilder {   
	"hello"("word")
    ref
}
```
