### PR TITLE
Fix jbr download folder name for JBR 17

### DIFF
--- a/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
@@ -69,6 +69,10 @@ open class DownloadJbrProjectPlugin : Plugin<Project> {
                 extractJbr.configure {
                     from({ configuration.resolve().map { tarTree(it) } })
                     into(downloadDir)
+                    includeEmptyDirs = false
+                    filesMatching("jbr*/**") {
+                        path = path.replace("jbr_(.*?)/(.*)".toRegex(), "jbr/$2")
+                    }
                 }
 
                 val jbrSubdir = when {


### PR DESCRIPTION
Starting from JBR 17, the folder is named jbr-[distributionType]-[version] and not just jbr.