### PR TITLE
feature: parameter for `generate` to enable parallel generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.17
+
+### Added
+
+- `generate` now supports `parallelGenerationThreads` option. Positive values will turn on parallel generation, and
+  the value will be used as the number of threads. The default is 0, which means no parallel generation.
+
 ## 1.16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Parameters:
 * `excludeModules` (since 1.14) - optional list of modules to exclude from generate. RegEx can be used for matching multiple modules.
 * `macros` - optional list of path macros. The notation is `new Macro("name", "value")`.
 * `projectLocation` - location of the MPS project to generate.
+* `parallelGenerationThreads` (since 1.17) - optional number of threads to use for parallel generation. Defaults to `0`, 
+  which means that parallel generation is turned off.
 * `debug` - optionally allows to start the JVM that is used to generated with a debugger. Setting it to `true` will cause
   the started JVM to suspend until a debugger is attached. Useful for debugging classloading problems or exceptions during
   the build.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 val versionMajor = 1
-val versionMinor = 16
+val versionMinor = 17
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/Common.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/Common.kt
@@ -15,7 +15,7 @@ private val logger = Logger.getLogger("de.itemis.mps.gradle.common")
 
 const val MPS_SUPPORT_MSG = "Version 1.8 doesn't only support MPS 2020.1+, please use versions 1.4 or below with older versions of MPS."
 
-const val MPS_BUILD_BACKENDS_VERSION = "[1.6,2.0)"
+const val MPS_BUILD_BACKENDS_VERSION = "[1.7,2.0)"
 
 data class Plugin(
         var id: String,

--- a/src/main/kotlin/de/itemis/mps/gradle/generate/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/generate/Plugin.kt
@@ -16,6 +16,7 @@ open class GeneratePluginExtensions(objectFactory: ObjectFactory): BasePluginExt
     var modules: List<String> = emptyList()
     var excludeModels: List<String> = emptyList()
     var excludeModules: List<String> = emptyList()
+    var parallelGenerationThreads: Int = 0
 }
 
 open class GenerateMpsProjectPlugin : Plugin<Project> {
@@ -67,12 +68,13 @@ open class GenerateMpsProjectPlugin : Plugin<Project> {
 
                     argumentProviders.add(argsFromBaseExtension(extension))
                     argumentProviders.add(CommandLineArgumentProvider {
-                        val args = mutableListOf<String>()
-                        args.addAll(extension.models.map { "--model=$it" })
-                        args.addAll(extension.modules.map { "--module=$it" })
-                        args.addAll(extension.excludeModels.map { "--exclude-model=$it" })
-                        args.addAll(extension.excludeModules.map { "--exclude-module=$it" })
-                        args
+                        mutableListOf<String>().apply {
+                            addAll(extension.models.map { "--model=$it" })
+                            addAll(extension.modules.map { "--module=$it" })
+                            addAll(extension.excludeModels.map { "--exclude-model=$it" })
+                            addAll(extension.excludeModules.map { "--exclude-module=$it" })
+                            add("--parallel-generation-threads=${extension.parallelGenerationThreads}")
+                        }
                     })
 
                     if (extension.javaExec != null)


### PR DESCRIPTION
Updates version of `mps-build-backends` to 1.17, 
adds support for the parameter to enable parallel generation

Relevant PR: https://github.com/mbeddr/mps-build-backends/pull/6