### PR TITLE
сhange/distinct exit code when nothing to generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.18
+
+### Changed
+
+- `generate`: exit code when there is nothing to generate is now `254` to distinguish it from the general MPS error.
+- `generate`: exit code for a general MPS error is now `255` on all systems. Changed from `-1`, which could  be 
+  interpreted as `255` or `-1` depending on the system.
+
 ## 1.17
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 val versionMajor = 1
-val versionMinor = 17
+val versionMinor = 18
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/Common.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/Common.kt
@@ -15,7 +15,7 @@ private val logger = Logger.getLogger("de.itemis.mps.gradle.common")
 
 const val MPS_SUPPORT_MSG = "Version 1.8 doesn't only support MPS 2020.1+, please use versions 1.4 or below with older versions of MPS."
 
-const val MPS_BUILD_BACKENDS_VERSION = "[1.7,2.0)"
+const val MPS_BUILD_BACKENDS_VERSION = "[1.9,2.0)"
 
 data class Plugin(
         var id: String,


### PR DESCRIPTION
Updated mps-build-backends to 1.9
Bumped version to 1.18

Changed: 
* distinct exit code (254) for generate when nothing to generate
* exit code for general MPS error fixed to 255 on all systems