### PR TITLE
Make downloadJbr accept the distributionType parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.22.0
+
+### Fixed
+
+- `downloadJbr` properly accepts the `distributionType` parameter 
+
 ## 1.21.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.22.0
+## 1.21.1
 
 ### Fixed
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
-val baseVersion = "1.21.0"
+val baseVersion = "1.22.0"
 
 group = "de.itemis.mps"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
-val baseVersion = "1.22.0"
+val baseVersion = "1.21.1"
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
@@ -95,12 +95,14 @@ open class DownloadJbrProjectPlugin : Plugin<Project> {
         // required for running tests. While a little bit larger than jbr_nomod it should cause the least
         // surprises when using it as a default.
         // see https://github.com/mbeddr/build.publish.jdk/commit/10bbf7d177336179ca189fc8bb4c1262029c69da
-        val distributionType = if(extension.distributionType == null &&
-            Regex("""11_0_[0-9][^0-9]""").find(version) != null) {
-            "jbr"
-        } else {
-            "jbr_jcef"
-        }
+        val distributionType =
+                if (extension.distributionType != null) {
+                    extension.distributionType
+                } else if (Regex("""11_0_[0-9][^0-9]""").find(version) != null) {
+                    "jbr"
+                } else {
+                    "jbr_jcef"
+                }
 
         val cpuArch = when(System.getProperty ("os.arch")) {
             "aarch64" -> "aarch64"


### PR DESCRIPTION
Previously the parameter was ignored, always downloading jbr or jbr_jcef depending on the version string.