### PR TITLE
downloadJbr: add support for Jbr versions with dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.21.2
+
+### Fixed
+
+- `downloadJbr` handles jbr versions with dashes in their name
+
 ## 1.21.1
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
-val baseVersion = "1.21.1"
+val baseVersion = "1.21.2"
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
@@ -46,7 +46,7 @@ open class DownloadJbrProjectPlugin : Plugin<Project> {
                             workingDir = downloadDir
                         }
 
-                        if (downloadDir.listFiles { _, name -> name.startsWith("jbr_") }!!.any()) {
+                        if (downloadDir.listFiles { _, name -> name.startsWith("jbr_") || name.startsWith("jbr-") }!!.any()) {
                             exec {
                                 commandLine("sh", "-c", "mv jbr_* jbr")
                                 workingDir = downloadDir

--- a/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Plugin.kt
@@ -48,7 +48,7 @@ open class DownloadJbrProjectPlugin : Plugin<Project> {
 
                         if (downloadDir.listFiles { _, name -> name.startsWith("jbr_") || name.startsWith("jbr-") }!!.any()) {
                             exec {
-                                commandLine("sh", "-c", "mv jbr_* jbr")
+                                commandLine("sh", "-c", "mv jbr* jbr")
                                 workingDir = downloadDir
                             }
                         }


### PR DESCRIPTION
Previously only jbr versions with an underscore were supported. Now `jbr-17...` works as well.