### PR TITLE
[breaking] MPS task interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.26.0
+
+### Changed
+
+- All MPS tasks now implement `MpsTask` interface which defines common properties. As a result, some tasks were
+  affected:
+  - `MpsCheck`: `pluginRoots` type was changed from `SetProperty<Directory>` to `ConfigurableFileCollection` because
+    the latter is easier to work with from Gradle. **This is a breaking change.**
+  - `MpsExecute`: `folderMacros` are now supported and will be passed to MPS.
+
+### Deprecated
+
+- `MpsCheck`, `MpsGenerate`, `MpsExecute`: `varMacros` (or `macros` in case of `MpsExecute`) are now deprecated and will 
+  be removed in a later release. Only folder macros (pointing to an existing directory) are supported by MPS, any
+  non-folder macros would not have worked properly anyway.
+
 ## 1.25.2
 
 ### Fixed

--- a/api/mps-gradle-plugin.api
+++ b/api/mps-gradle-plugin.api
@@ -302,29 +302,25 @@ public final class de/itemis/mps/gradle/runmigrations/RunMigrationsMpsProjectPlu
 	public final fun getMIN_VERSION_FOR_HALT_ON_PRECHECK_FAILURE ()Lnet/swiftzer/semver/SemVer;
 }
 
-public abstract class de/itemis/mps/gradle/tasks/MpsCheck : org/gradle/api/tasks/JavaExec, org/gradle/api/tasks/VerificationTask {
+public abstract class de/itemis/mps/gradle/tasks/MpsCheck : org/gradle/api/tasks/JavaExec, de/itemis/mps/gradle/tasks/MpsTask, org/gradle/api/tasks/VerificationTask {
 	public fun <init> ()V
 	public fun exec ()V
 	public final fun getAdditionalModelcheckBackendClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	protected final fun getCompiledClasses ()Lorg/gradle/api/file/FileTree;
 	public final fun getExcludeModels ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getExcludeModules ()Lorg/gradle/api/provider/ListProperty;
-	public final fun getFolderMacros ()Lorg/gradle/api/provider/MapProperty;
 	public final fun getJunitFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public final fun getJunitFormat ()Lorg/gradle/api/provider/Property;
 	public final fun getModels ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getModules ()Lorg/gradle/api/provider/ListProperty;
-	public final fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public final fun getMpsVersion ()Lorg/gradle/api/provider/Property;
 	public final fun getParallel ()Lorg/gradle/api/provider/Property;
-	public final fun getPluginRoots ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getProjectLocation ()Lorg/gradle/api/file/DirectoryProperty;
 	protected final fun getSources ()Lorg/gradle/api/file/FileTree;
 	public final fun getVarMacros ()Lorg/gradle/api/provider/MapProperty;
 	public final fun getWarningAsError ()Lorg/gradle/api/provider/Property;
 }
 
-public abstract class de/itemis/mps/gradle/tasks/MpsExecute : org/gradle/api/tasks/JavaExec {
+public abstract class de/itemis/mps/gradle/tasks/MpsExecute : org/gradle/api/tasks/JavaExec, de/itemis/mps/gradle/tasks/MpsTask {
 	public fun <init> ()V
 	public fun exec ()V
 	public final fun getAdditionalExecuteBackendClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
@@ -333,13 +329,10 @@ public abstract class de/itemis/mps/gradle/tasks/MpsExecute : org/gradle/api/tas
 	public abstract fun getMethod ()Lorg/gradle/api/provider/Property;
 	public abstract fun getMethodArguments ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getModule ()Lorg/gradle/api/provider/Property;
-	public abstract fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public abstract fun getMpsVersion ()Lorg/gradle/api/provider/Property;
-	public abstract fun getPluginRoots ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getProjectLocation ()Lorg/gradle/api/file/DirectoryProperty;
 }
 
-public abstract class de/itemis/mps/gradle/tasks/MpsGenerate : org/gradle/api/tasks/JavaExec {
+public abstract class de/itemis/mps/gradle/tasks/MpsGenerate : org/gradle/api/tasks/JavaExec, de/itemis/mps/gradle/tasks/MpsTask {
 	public fun <init> ()V
 	public fun exec ()V
 	public final fun getAdditionalGenerateBackendClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
@@ -347,46 +340,41 @@ public abstract class de/itemis/mps/gradle/tasks/MpsGenerate : org/gradle/api/ta
 	public final fun getEnvironmentKind ()Lorg/gradle/api/provider/Property;
 	public final fun getExcludeModels ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getExcludeModules ()Lorg/gradle/api/provider/ListProperty;
-	public final fun getFolderMacros ()Lorg/gradle/api/provider/MapProperty;
 	public final fun getModels ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getModules ()Lorg/gradle/api/provider/ListProperty;
-	public final fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public final fun getMpsVersion ()Lorg/gradle/api/provider/Property;
 	public final fun getParallelGenerationThreads ()Lorg/gradle/api/provider/Property;
-	public final fun getPluginRoots ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getProjectLocation ()Lorg/gradle/api/file/DirectoryProperty;
 	protected final fun getSources ()Lorg/gradle/api/file/FileTree;
 	public final fun getStrictMode ()Lorg/gradle/api/provider/Property;
 	public final fun getVarMacros ()Lorg/gradle/api/provider/MapProperty;
 }
 
-public abstract class de/itemis/mps/gradle/tasks/MpsMigrate : org/gradle/api/DefaultTask {
+public abstract class de/itemis/mps/gradle/tasks/MpsMigrate : org/gradle/api/DefaultTask, de/itemis/mps/gradle/tasks/MpsTask {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/provider/ProviderFactory;)V
 	public final fun execute ()V
 	protected final fun getAllProjectFiles ()Lorg/gradle/api/provider/Provider;
 	public final fun getAntJvmArgs ()Lorg/gradle/api/provider/ListProperty;
-	public final fun getFolderMacros ()Lorg/gradle/api/provider/MapProperty;
 	public final fun getHaltOnDependencyError ()Lorg/gradle/api/provider/Property;
 	public final fun getHaltOnPrecheckFailure ()Lorg/gradle/api/provider/Property;
 	public final fun getJavaExecutable ()Lorg/gradle/api/file/RegularFileProperty;
 	public final fun getJavaLauncher ()Lorg/gradle/api/provider/Property;
 	public final fun getJvmArgs ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getMaxHeapSize ()Lorg/gradle/api/provider/Property;
-	public final fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public final fun getMpsVersion ()Lorg/gradle/api/provider/Property;
-	public final fun getPluginRoots ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getProjectDirectories ()Lorg/gradle/api/file/ConfigurableFileCollection;
 }
 
-public class de/itemis/mps/gradle/tasks/Remigrate : org/gradle/api/tasks/JavaExec {
+public abstract interface class de/itemis/mps/gradle/tasks/MpsTask : org/gradle/api/Task {
+	public abstract fun getFolderMacros ()Lorg/gradle/api/provider/MapProperty;
+	public abstract fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getMpsVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getPluginRoots ()Lorg/gradle/api/file/ConfigurableFileCollection;
+}
+
+public abstract class de/itemis/mps/gradle/tasks/Remigrate : org/gradle/api/tasks/JavaExec, de/itemis/mps/gradle/tasks/MpsTask {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/provider/ProviderFactory;)V
 	public fun exec ()V
 	public final fun getAdditionalClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	protected final fun getAllProjectFiles ()Lorg/gradle/api/provider/Provider;
-	public final fun getFolderMacros ()Lorg/gradle/api/provider/MapProperty;
-	public final fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public final fun getMpsVersion ()Lorg/gradle/api/provider/Property;
-	public final fun getPluginRoots ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getProjectDirectories ()Lorg/gradle/api/file/ConfigurableFileCollection;
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
-val baseVersion = "1.25.2"
+val baseVersion = "1.26.0"
 
 group = "de.itemis.mps"
 

--- a/docs/tasks/MpsCheck.md
+++ b/docs/tasks/MpsCheck.md
@@ -34,14 +34,13 @@ Parameters:
   backend.
 * `folderMacros` - path variables/macros that are necessary to open the project. Path macros are not considered part of
   Gradle build cache key.
-* `varMacros` - non-path variables/macros that are necessary to open the project. Variable macros *are* considered part
-  of Gradle build cache key.
+* `varMacros` - Deprecated and will be removed (only folder macros are supported by MPS).
 * `junitFile` - the JUnit XML file to produce. Defaults to `$buildDir/TEST-${task.name}.xml`
 * `junitFormat` - the format of the JUnit XML file. Defaults to `module-and-model`.
 * `parallel` (since 1.20) - runs model checker in parallel mode. Supported in MPS 2021.3.4. Default is `false`.
 * `mpsHome` - the home directory of the MPS distribution (or RCP) to use for testing.
 * `mpsVersion` - the MPS version, such as "2021.3". Autodetected by reading `$mpsHome/build.properties` by default.
-* `pluginRoots` - directories containing additional plugins to load
+* `pluginRoots` - directories that will be searched (recursively) for additional plugins to load.
 * `warningAsError` - whether to treat warnings as errors.
 * `ignoreFailures` (inherited from `VerificationTask`) - whether to fail the build if an error is found.
 

--- a/docs/tasks/MpsExecute.md
+++ b/docs/tasks/MpsExecute.md
@@ -27,10 +27,10 @@ Parameters:
 
 * `projectLocation` - the location of the MPS project. Default is the Gradle project directory.
 * `additionalExecuteBackendClasspath` - any extra libraries that should be on the classpath of the execute backend.
-* `macros` - variables/macros that are necessary to open the project.
+* `folderMacros` - folder/path macros that are necessary to open the project.
 * `mpsHome` - the home directory of the MPS distribution (or RCP) to use for testing.
 * `mpsVersion` - the MPS version, such as "2021.3". Default is autodetection by reading `$mpsHome/build.properties`.
-* `pluginRoots` - directories containing additional plugins to load.
+* `pluginRoots` - directories that will be searched (recursively) for additional plugins to load.
 * `module` - the module that contains the generated class.
 * `className` - fully qualified name of the generated class, that contains the method to execute.
 * `method` - name of the method. The method should be public and static. Supported signatures are `(Project)` (from

--- a/docs/tasks/MpsGenerate.md
+++ b/docs/tasks/MpsGenerate.md
@@ -34,11 +34,10 @@ Parameters:
   backend.
 * `folderMacros` - path variables/macros that are necessary to open the project. Path macros are not considered part of
   Gradle build cache key.
-* `varMacros` - non-path variables/macros that are necessary to open the project. Variable macros *are* considered part
-  of Gradle build cache key.
+* `varMacros` - Deprecated and will be removed (only folder macros are supported by MPS).
 * `mpsHome` - the home directory of the MPS distribution (or RCP) to use for testing.
 * `mpsVersion` - the MPS version, such as "2021.3". Autodetected by reading `$mpsHome/build.properties` by default.
-* `pluginRoots` - directories with additional plugins to load.
+* `pluginRoots` - directories that will be searched (recursively) for additional plugins to load.
 * `environmentKind` - the environment to use for generation (`MPS` or `IDEA`). MPS environment is used by default,
   matching the standard `<generate>` Ant task. IDEA environment can be used when generating screenshots.
   See [MPS vs IDEA environment](../notes/mps-vs-idea-environment.md).

--- a/src/main/kotlin/de/itemis/mps/gradle/common.gradle.kts
+++ b/src/main/kotlin/de/itemis/mps/gradle/common.gradle.kts
@@ -1,9 +1,16 @@
 package de.itemis.mps.gradle
 
+import de.itemis.mps.gradle.launcher.MpsVersionDetection
+import de.itemis.mps.gradle.tasks.MpsTask
+
 /**
  * A side effect of this plugin is that it lets us use `plugins` block rather than `buildscript` to put the task classes
  * ([RunAntScript], [BuildLanguages], etc.) onto the classpath.
  */
+
+tasks.withType(MpsTask::class.java).configureEach {
+    mpsVersion.convention(MpsVersionDetection.fromMpsHome(project.layout, providers, mpsHome.asFile))
+}
 
 val modelcheckBackend = configurations.create(BackendConfigurations.MODELCHECK_BACKEND_CONFIGURATION_NAME)
 val generateBackend = configurations.create(BackendConfigurations.GENERATE_BACKEND_CONFIGURATION_NAME)

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsMigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsMigrate.kt
@@ -29,15 +29,7 @@ import javax.inject.Inject
 abstract class MpsMigrate @Inject constructor(
     objectFactory: ObjectFactory,
     providerFactory: ProviderFactory
-) : DefaultTask() {
-
-    @get:Internal
-    val mpsHome: DirectoryProperty = objectFactory.directoryProperty()
-
-    @get:Input
-    @get:Optional
-    val mpsVersion: Property<String> = objectFactory.property<String>()
-        .convention(MpsVersionDetection.fromMpsHome(project.layout, providerFactory, mpsHome.asFile))
+) : MpsTask, DefaultTask() {
 
     /**
      * (Since MPS 2021.1) Whether to halt if a pre-check has failed. Note that to ignore the check for migrated
@@ -78,12 +70,6 @@ abstract class MpsMigrate @Inject constructor(
     @get:Input
     @get:Optional
     val maxHeapSize: Property<String> = objectFactory.property()
-
-    @get:Internal("Folder macros are ignored for the purposes of up-to-date checks and caching")
-    val folderMacros: MapProperty<String, Directory> = objectFactory.mapProperty()
-
-    @get:Classpath
-    val pluginRoots: ConfigurableFileCollection = objectFactory.fileCollection()
 
     init {
         group = TaskGroups.MIGRATION
@@ -150,6 +136,7 @@ abstract class MpsMigrate @Inject constructor(
                     }
 
                     val folderMacrosValue = folderMacros.get()
+
                     val allLibraries = projectDirectories
                         .flatMap { readLibraries(it, folderMacrosValue::get) }
                         .toSortedSet()

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsTask.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsTask.kt
@@ -1,0 +1,30 @@
+package de.itemis.mps.gradle.tasks
+
+import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+
+/**
+ * A common interface for all tasks that use MPS, either to launch a backend or to call an Ant task.
+ */
+interface MpsTask : Task {
+    @get:Internal("covered by mpsVersion and other properties")
+    val mpsHome: DirectoryProperty
+
+    @get:Input
+    @get:Optional
+    val mpsVersion: Property<String>
+
+    @get:Internal("Folder macros are ignored for the purposes of up-to-date checks and caching")
+    val folderMacros: MapProperty<String, Directory>
+
+    @get:Classpath
+    val pluginRoots: ConfigurableFileCollection
+}

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/PluginIds.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/PluginIds.kt
@@ -15,7 +15,7 @@ import java.util.jar.JarFile
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
 
-internal val logger = LoggerFactory.getLogger("de.itemis.mps.gradle.tasks.PluginIds")!!
+private val logger = LoggerFactory.getLogger("de.itemis.mps.gradle.tasks.PluginIds")!!
 
 internal fun findPluginsRecursively(root: File): List<Plugin> = mutableListOf<Plugin>().apply {
     if (!root.isDirectory) {

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
@@ -3,36 +3,21 @@ package de.itemis.mps.gradle.tasks
 import de.itemis.mps.gradle.BackendConfigurations
 import de.itemis.mps.gradle.TaskGroups
 import de.itemis.mps.gradle.launcher.MpsBackendBuilder
-import de.itemis.mps.gradle.launcher.MpsVersionDetection
 import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.MapProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.*
-import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.newInstance
-import org.gradle.kotlin.dsl.property
 import org.gradle.process.CommandLineArgumentProvider
 import javax.inject.Inject
 
 @Incubating
 @UntrackedTask(because = "Operates 'in place'")
-open class Remigrate @Inject constructor(
+abstract class Remigrate @Inject constructor(
     objectFactory: ObjectFactory,
     providerFactory: ProviderFactory
-) : JavaExec() {
-
-    @get:Internal
-    val mpsHome: DirectoryProperty = objectFactory.directoryProperty()
-
-    @get:Input
-    @get:Optional
-    val mpsVersion: Property<String> = objectFactory.property<String>()
-        .convention(MpsVersionDetection.fromMpsHome(project.layout, providerFactory, mpsHome.asFile))
+) : MpsTask, JavaExec() {
 
     @get:Internal("covered by allProjectFiles")
     val projectDirectories: ConfigurableFileCollection = objectFactory.fileCollection()
@@ -41,12 +26,6 @@ open class Remigrate @Inject constructor(
     @get:SkipWhenEmpty
     @get:IgnoreEmptyDirectories
     protected val allProjectFiles = providerFactory.provider { projectDirectories.flatMap { objectFactory.fileTree().from(it) } }
-
-    @get:Internal("Folder macros are ignored for the purposes of up-to-date checks and caching")
-    val folderMacros: MapProperty<String, Directory> = objectFactory.mapProperty()
-
-    @get:Classpath
-    val pluginRoots: ConfigurableFileCollection = objectFactory.fileCollection()
 
     @get:Internal
     val additionalClasspath: ConfigurableFileCollection =
@@ -60,6 +39,7 @@ open class Remigrate @Inject constructor(
         val backendConfig = project.configurations.named(BackendConfigurations.REMIGRATE_BACKEND_CONFIGURATION_NAME)
         dependsOn(backendConfig)
 
+        argumentProviders.add(backendArguments())
         argumentProviders.add(CommandLineArgumentProvider {
             val result = mutableListOf<String>()
 
@@ -67,9 +47,6 @@ open class Remigrate @Inject constructor(
                 result.add("--project=$dir")
             }
 
-            addPluginRoots(result, pluginRoots)
-            addLogLevel(result)
-            addFolderMacros(result, folderMacros)
             result.add("--plugin=de.itemis.mps.buildbackends.remigrate::" +
                     backendConfig.get().files(backendConfig.get().dependencies.first()).first())
 

--- a/src/test/kotlin/test/modelchecking/MpsCheckTaskTest.kt
+++ b/src/test/kotlin/test/modelchecking/MpsCheckTaskTest.kt
@@ -82,7 +82,7 @@ class MpsCheckTaskTest {
                 mpsHome.set(layout.dir(resolveMps.map { it.destinationDir }))
                 projectLocation.set(file("mps-prj"))
                 junitFile.set(layout.buildDirectory.file("output.xml"))
-                pluginRoots.add(layout.dir(resolveMps.map { File(it.destinationDir, "plugins/mps-console") }))
+                pluginRoots.from(layout.dir(resolveMps.map { File(it.destinationDir, "plugins/mps-console") }))
             }
         """.trimIndent())
 


### PR DESCRIPTION
### Changed

- All MPS tasks now implement `MpsTask` interface which defines common properties. As a result, some tasks were
  affected (all marked as `@Incubating`):
  - `MpsCheck`: `pluginRoots` type was changed from `SetProperty<Directory>` to `ConfigurableFileCollection` because the latter is easier to work with from Gradle. **This is a breaking change.**
  - `MpsExecute`: `folderMacros` are now supported and will be passed to MPS.

### Deprecated

- `MpsCheck`, `MpsGenerate`, `MpsExecute`: `varMacros` (or `macros` in case of `MpsExecute`) are now deprecated and will be removed in a later release. Only folder macros (pointing to an existing directory) are supported by MPS, any non-folder macros would not have worked properly anyway.