### PR TITLE
1.29.0: reverse classpath order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.29.0
+
+- `MpsCheck`, `MpsGenerate`, `MpsExecute`: put MPS jars at the beginning of the classpath of the corresponding backends,
+  in an attempt to solve incompatibility between the Kotlin version that the backends are built against and the Kotlin
+  version included in newer MPS versions (2024.1+).
+
 ## 1.28.0
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
-val baseVersion = "1.28.0"
+val baseVersion = "1.29.0"
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
@@ -1,28 +1,24 @@
 package de.itemis.mps.gradle.tasks
 
 import de.itemis.mps.gradle.BackendConfigurations
-import de.itemis.mps.gradle.ErrorMessages
 import de.itemis.mps.gradle.TaskGroups
 import de.itemis.mps.gradle.launcher.MpsBackendBuilder
 import de.itemis.mps.gradle.launcher.MpsVersionDetection
-import org.gradle.api.GradleException
 import org.gradle.api.Incubating
 import org.gradle.api.file.*
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.*
-import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.process.CommandLineArgumentProvider
 
 @CacheableTask
 @Incubating
 abstract class MpsCheck : JavaExec(), VerificationTask {
 
-    @get:Internal("covered by mpsVersion, initialModelcheckBackendClasspath()")
+    @get:Internal("covered by mpsVersion, classpath")
     val mpsHome: DirectoryProperty = objectFactory.directoryProperty()
 
     @get:Input
@@ -69,8 +65,7 @@ abstract class MpsCheck : JavaExec(), VerificationTask {
     val parallel: Property<Boolean> = objectFactory.property<Boolean>().convention(false)
 
     @get:Internal("covered by classpath")
-    val additionalModelcheckBackendClasspath: ConfigurableFileCollection =
-        objectFactory.fileCollection().from(initialModelcheckBackendClasspath())
+    val additionalModelcheckBackendClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
 
     @Suppress("unused")
     @get:InputFiles
@@ -142,6 +137,7 @@ abstract class MpsCheck : JavaExec(), VerificationTask {
 
         group = TaskGroups.VERIFICATION
 
+        classpath(mpsAndPluginJars())
         classpath(project.configurations.named(BackendConfigurations.MODELCHECK_BACKEND_CONFIGURATION_NAME))
         classpath(additionalModelcheckBackendClasspath)
 
@@ -153,7 +149,7 @@ abstract class MpsCheck : JavaExec(), VerificationTask {
         super.exec()
     }
 
-    private fun initialModelcheckBackendClasspath() = mpsHome.asFileTree.matching {
+    private fun mpsAndPluginJars() = mpsHome.asFileTree.matching {
         include("lib/**/*.jar")
 
         // add only minimal number of plugins jars that are required by the modelcheck code

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
@@ -1,15 +1,12 @@
 package de.itemis.mps.gradle.tasks
 
 import de.itemis.mps.gradle.BackendConfigurations
-import de.itemis.mps.gradle.ErrorMessages
 import de.itemis.mps.gradle.launcher.MpsBackendBuilder
 import de.itemis.mps.gradle.launcher.MpsVersionDetection
-import org.gradle.api.GradleException
 import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -51,8 +48,7 @@ abstract class MpsExecute : JavaExec() {
     abstract val methodArguments: ListProperty<String>
 
     @get:Internal
-    val additionalExecuteBackendClasspath: ConfigurableFileCollection =
-        objectFactory.fileCollection().from(initialExecuteBackendClasspath())
+    val additionalExecuteBackendClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
 
     init {
         mpsVersion.convention(MpsVersionDetection.fromMpsHome(project.layout, providerFactory, mpsHome.asFile))
@@ -82,6 +78,7 @@ abstract class MpsExecute : JavaExec() {
         description = "Execute specified method from a generated class to modify the MPS project"
         group = "execute"
 
+        classpath(mpsJars())
         classpath(project.configurations.named(BackendConfigurations.EXECUTE_BACKEND_CONFIGURATION_NAME))
         classpath(additionalExecuteBackendClasspath)
 
@@ -95,7 +92,7 @@ abstract class MpsExecute : JavaExec() {
         super.exec()
     }
 
-    private fun initialExecuteBackendClasspath() = mpsHome.asFileTree.matching {
+    private fun mpsJars() = mpsHome.asFileTree.matching {
         include("lib/**/*.jar")
     }
 }

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
@@ -10,7 +10,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -25,7 +24,7 @@ import org.gradle.process.CommandLineArgumentProvider
 @Incubating
 abstract class MpsGenerate : JavaExec() {
 
-    @get:Internal("covered by mpsVersion, initialGenerateBackendClasspath()")
+    @get:Internal("covered by mpsVersion, classpath")
     val mpsHome: DirectoryProperty = objectFactory.directoryProperty()
 
     @get:Input
@@ -69,8 +68,7 @@ abstract class MpsGenerate : JavaExec() {
     val parallelGenerationThreads: Property<Int> = objectFactory.property<Int>().convention(0)
 
     @get:Internal("covered by classpath")
-    val additionalGenerateBackendClasspath: ConfigurableFileCollection =
-        objectFactory.fileCollection().from(initialGenerateBackendClasspath())
+    val additionalGenerateBackendClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
 
     @Suppress("unused")
     @get:InputFiles
@@ -127,8 +125,9 @@ abstract class MpsGenerate : JavaExec() {
 
         group = TaskGroups.GENERATION
 
-        classpath(project.configurations.named(BackendConfigurations.GENERATE_BACKEND_CONFIGURATION_NAME))
+        classpath(mpsJars())
         classpath(additionalGenerateBackendClasspath)
+        classpath(project.configurations.named(BackendConfigurations.GENERATE_BACKEND_CONFIGURATION_NAME))
 
         mainClass.set("de.itemis.mps.gradle.generate.MainKt")
     }
@@ -139,7 +138,7 @@ abstract class MpsGenerate : JavaExec() {
         super.exec()
     }
 
-    private fun initialGenerateBackendClasspath() = mpsHome.asFileTree.matching {
+    private fun mpsJars() = mpsHome.asFileTree.matching {
         include("lib/**/*.jar")
     }
 }


### PR DESCRIPTION
The plugin currently does not work with MPS 2024.1 due to some Kotlin incompatibilities. Reversing the order of jars on the backend classpath, putting MPS jars first, seems to solve this for the integration tests of the backends, so let's try the same approach here.