### PR TITLE
1.29.1: support Gradle 8.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## 1.29.1
+
+### Fixed
+
+- Exception on Gradle 8.13:
+  ```
+  java.lang.NoSuchMethodError: 'org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec.fromJavaExecutable(org.gradle.api.model.ObjectFactory, java.lang.String)'
+  ```
+
 ## 1.29.0
 
 - `MpsCheck`, `MpsGenerate`, `MpsExecute`: put MPS jars at the beginning of the classpath of the corresponding backends,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
-val baseVersion = "1.29.0"
+val baseVersion = "1.29.1"
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Tasks.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/Tasks.kt
@@ -14,9 +14,11 @@ import java.io.File
 import javax.inject.Inject
 
 open class DownloadJbrForPlatform @Inject constructor(
-    private val objects: ObjectFactory,
+    objects: ObjectFactory,
     private val javaToolchainService: JavaToolchainService
 ) : DefaultTask() {
+
+    private val toolchainSpecFactory = objects.newInstance(ToolchainSpecFactory::class.java)
 
     @get:Internal
     internal val jbrDirProperty: DirectoryProperty = objects.directoryProperty()
@@ -44,7 +46,7 @@ open class DownloadJbrForPlatform @Inject constructor(
      */
     @get:Internal
     val toolchainSpec: Provider<JavaToolchainSpec> =
-        javaExecutableProperty.map { SpecificInstallationToolchainSpec.fromJavaExecutable(objects, it.asFile.path) }
+        javaExecutableProperty.map { toolchainSpecFactory.fromJavaExecutable(it.asFile.path) }
 
     /**
      * A [JavaLauncher] for the downloaded JBR that can be used with [JavaExec] task.

--- a/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/ToolchainSpecFactory.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/downloadJBR/ToolchainSpecFactory.kt
@@ -1,0 +1,37 @@
+package de.itemis.mps.gradle.downloadJBR
+
+import org.gradle.api.internal.provider.PropertyFactory
+import org.gradle.api.model.ObjectFactory
+import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec
+import javax.inject.Inject
+
+internal abstract class ToolchainSpecFactory {
+    @get:Inject
+    abstract val propertyFactory: PropertyFactory
+
+    val method813 = try {
+        SpecificInstallationToolchainSpec::class.java.getMethod("fromJavaExecutable",
+            PropertyFactory::class.java, String::class.java)
+    } catch (_: NoSuchMethodException) {
+        null
+    }
+
+    @get:Inject
+    abstract val objectFactory: ObjectFactory
+
+    val method812 = try {
+        SpecificInstallationToolchainSpec::class.java.getMethod("fromJavaExecutable",
+            ObjectFactory::class.java, String::class.java)
+    } catch (_: NoSuchMethodException) {
+        null
+    }
+
+    fun fromJavaExecutable(javaExecutable: String): SpecificInstallationToolchainSpec =
+        if (method813 != null) {
+            method813.invoke(null, propertyFactory, javaExecutable) as SpecificInstallationToolchainSpec
+        } else if (method812 != null) {
+            method812.invoke(null, objectFactory, javaExecutable) as SpecificInstallationToolchainSpec
+        } else  {
+            throw IllegalStateException("Unsupported Gradle version, cannot create a SpecificInstallationToolchainSpec")
+        }
+}

--- a/src/test/kotlin/test/others/JBRDownloadTest.kt
+++ b/src/test/kotlin/test/others/JBRDownloadTest.kt
@@ -61,6 +61,7 @@ class JBRDownloadTest {
         Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":downloadJbr")?.outcome)
         Assert.assertTrue(File(testProjectDir.root, "jbrdl").exists())
     }
+
     @Test
     fun `download without download dir`() {
         settingsFile.writeText("""
@@ -242,6 +243,46 @@ class JBRDownloadTest {
         val result = GradleRunner.create()
             .withProjectDir(testProjectDir.root)
             .withArguments("exec")
+            .withPluginClasspath()
+            .build()
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":exec")?.outcome)
+        assertThat(result.output, containsString("OpenJDK Runtime Environment JBR"))
+    }
+
+    @Test
+    fun `use JavaLauncher with Gradle 8_13`() {
+        buildFile.writeText("""
+            import de.itemis.mps.gradle.downloadJBR.DownloadJbrForPlatform
+
+            plugins {
+                id("download-jbr")
+            }
+            
+            repositories {
+                mavenCentral()
+                maven("https://artifacts.itemis.cloud/repository/maven-mps")
+            }
+            
+            downloadJbr {
+                jbrVersion = "$JBR_VERSION"
+            }
+            
+            val downloadJbrTask = tasks.named("downloadJbr", DownloadJbrForPlatform::class)
+            
+            tasks.register<JavaExec>("exec") {
+                dependsOn(downloadJbrTask)
+                javaLauncher.set(downloadJbrTask.flatMap { it.javaLauncher })
+                jvmArgs("--version")
+
+                // Main class will be ignored due to --version but has to be provided
+                mainClass.set("ignored")
+            }
+        """.trimIndent())
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("exec")
+            .withGradleVersion("8.13")
             .withPluginClasspath()
             .build()
         Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":exec")?.outcome)


### PR DESCRIPTION
Gradle SpecificInstallationToolchainSpec internal API changed between 8.12.1 and 8.13. Gradle currently offers no other option to create a toolchain from a specific installation (gradle/gradle#16245) so use reflection to work around this.