### PR TITLE
Avoid calling `Task.project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.29.2
+
+### Fixed
+
+- Removes usage of `Task.getProject()` to be compatible with the Gradle configuration cache, see https://docs.gradle.org/8.12.1/userguide/upgrading_version_7.html#task_project
 
 ## 1.29.1
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
-val baseVersion = "1.29.1"
+val baseVersion = "1.29.2"
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
@@ -17,7 +17,7 @@ internal fun Task.addLogLevel(args: MutableCollection<String>) = addIfInfoLogLev
  * attributes.
  */
 internal fun <T> Task.addIfInfoLogLevel(result: MutableCollection<T>, value: T) {
-    val effectiveLogLevel = logging.level ?: project.logging.level ?: project.gradle.startParameter.logLevel
+    val effectiveLogLevel = logging.level ?: project.gradle.startParameter.logLevel
     if (effectiveLogLevel <= LogLevel.INFO) result.add(value)
 }
 


### PR DESCRIPTION
See the docs:
- https://docs.gradle.org/8.12.1/userguide/upgrading_version_7.html#task_project
- https://docs.gradle.org/8.12.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

Which suggest to use `Task.logger` directly instead to be compatible with the configuration cache.