### PR TITLE
Remove another usage of `Task.getProject()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.29.3
+
+### Fixed
+
+- Removes another usage of `Task.getProject()` to be compatible with the Gradle configuration cache, see https://docs.gradle.org/8.12.1/userguide/upgrading_version_7.html#task_project
+
 ## 1.29.2
 
 ### Fixed

--- a/api/mps-gradle-plugin.api
+++ b/api/mps-gradle-plugin.api
@@ -327,6 +327,7 @@ public abstract class de/itemis/mps/gradle/tasks/MpsCheck : org/gradle/api/tasks
 	public final fun getFolderMacros ()Lorg/gradle/api/provider/MapProperty;
 	public final fun getJunitFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public final fun getJunitFormat ()Lorg/gradle/api/provider/Property;
+	public final fun getLogLevel ()Lorg/gradle/api/provider/Property;
 	public final fun getModels ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getModules ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
@@ -344,6 +345,7 @@ public abstract class de/itemis/mps/gradle/tasks/MpsExecute : org/gradle/api/tas
 	public fun exec ()V
 	public final fun getAdditionalExecuteBackendClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getClassName ()Lorg/gradle/api/provider/Property;
+	public final fun getLogLevel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getMacros ()Lorg/gradle/api/provider/MapProperty;
 	public abstract fun getMethod ()Lorg/gradle/api/provider/Property;
 	public abstract fun getMethodArguments ()Lorg/gradle/api/provider/ListProperty;
@@ -363,6 +365,7 @@ public abstract class de/itemis/mps/gradle/tasks/MpsGenerate : org/gradle/api/ta
 	public final fun getExcludeModels ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getExcludeModules ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getFolderMacros ()Lorg/gradle/api/provider/MapProperty;
+	public final fun getLogLevel ()Lorg/gradle/api/provider/Property;
 	public final fun getModels ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getModules ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
@@ -386,6 +389,7 @@ public abstract class de/itemis/mps/gradle/tasks/MpsMigrate : org/gradle/api/Def
 	public final fun getJavaExecutable ()Lorg/gradle/api/file/RegularFileProperty;
 	public final fun getJavaLauncher ()Lorg/gradle/api/provider/Property;
 	public final fun getJvmArgs ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getLogLevel ()Lorg/gradle/api/provider/Property;
 	public final fun getMaxHeapSize ()Lorg/gradle/api/provider/Property;
 	public final fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getMpsVersion ()Lorg/gradle/api/provider/Property;
@@ -401,6 +405,7 @@ public class de/itemis/mps/gradle/tasks/Remigrate : org/gradle/api/tasks/JavaExe
 	protected final fun getAllProjectFiles ()Lorg/gradle/api/provider/Provider;
 	public final fun getExcludedModuleMigrations ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getFolderMacros ()Lorg/gradle/api/provider/MapProperty;
+	public final fun getLogLevel ()Lorg/gradle/api/provider/Property;
 	public final fun getMpsHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getMpsVersion ()Lorg/gradle/api/provider/Property;
 	public final fun getPluginRoots ()Lorg/gradle/api/file/ConfigurableFileCollection;

--- a/api/mps-gradle-plugin.api
+++ b/api/mps-gradle-plugin.api
@@ -345,7 +345,7 @@ public abstract class de/itemis/mps/gradle/tasks/MpsExecute : org/gradle/api/tas
 	public fun exec ()V
 	public final fun getAdditionalExecuteBackendClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getClassName ()Lorg/gradle/api/provider/Property;
-	public final fun getLogLevel ()Lorg/gradle/api/provider/Property;
+	public abstract fun getLogLevel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getMacros ()Lorg/gradle/api/provider/MapProperty;
 	public abstract fun getMethod ()Lorg/gradle/api/provider/Property;
 	public abstract fun getMethodArguments ()Lorg/gradle/api/provider/ListProperty;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
 }
 
-val baseVersion = "1.29.2"
+val baseVersion = "1.29.3"
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
@@ -19,7 +19,7 @@ import org.gradle.process.CommandLineArgumentProvider
 @Incubating
 abstract class MpsCheck : JavaExec(), VerificationTask {
 
-    @get:Internal
+    @get:Input
     val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal("covered by mpsVersion, classpath")

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
@@ -134,7 +134,9 @@ abstract class MpsCheck : JavaExec(), VerificationTask {
                 result.add("--parallel")
             }
 
-            addLogLevel(result, logLevel.get())
+            if (logLevel.get() <= LogLevel.INFO) {
+                result.add("--log-level=${logLevel.get()}")
+            }
 
             result
         })

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
@@ -6,6 +6,7 @@ import de.itemis.mps.gradle.launcher.MpsBackendBuilder
 import de.itemis.mps.gradle.launcher.MpsVersionDetection
 import org.gradle.api.Incubating
 import org.gradle.api.file.*
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -17,6 +18,9 @@ import org.gradle.process.CommandLineArgumentProvider
 @CacheableTask
 @Incubating
 abstract class MpsCheck : JavaExec(), VerificationTask {
+
+    @get:Internal
+    val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal("covered by mpsVersion, classpath")
     val mpsHome: DirectoryProperty = objectFactory.directoryProperty()
@@ -130,7 +134,7 @@ abstract class MpsCheck : JavaExec(), VerificationTask {
                 result.add("--parallel")
             }
 
-            addLogLevel(result)
+            addLogLevel(result, logLevel.get())
 
             result
         })

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
@@ -76,7 +76,9 @@ abstract class MpsExecute : JavaExec() {
                 add("--method=${method.get()}")
                 methodArguments.get().forEach { add("--arg=$it") }
 
-                addLogLevel(this, logLevel.get())
+                if (logLevel.get() <= LogLevel.INFO) {
+                    add("--log-level=${logLevel.get()}")
+                }
             }
         }
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
@@ -7,18 +7,26 @@ import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.property
 import org.gradle.work.DisableCachingByDefault
 
 
 @DisableCachingByDefault(because = "calls arbitrary user code")
 @Incubating
 abstract class MpsExecute : JavaExec() {
+
+    @get:Internal
+    val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal
     abstract val mpsHome: DirectoryProperty
@@ -71,7 +79,7 @@ abstract class MpsExecute : JavaExec() {
                 add("--method=${method.get()}")
                 methodArguments.get().forEach { add("--arg=$it") }
 
-                addLogLevel(this)
+                addLogLevel(this, logLevel.get())
             }
         }
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
@@ -12,10 +12,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import org.gradle.api.tasks.Classpath
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.JavaExec
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
 import org.gradle.work.DisableCachingByDefault
@@ -25,7 +22,7 @@ import org.gradle.work.DisableCachingByDefault
 @Incubating
 abstract class MpsExecute : JavaExec() {
 
-    @get:Internal
+    @get:Input
     val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
@@ -14,7 +14,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.newInstance
-import org.gradle.kotlin.dsl.property
 import org.gradle.work.DisableCachingByDefault
 
 
@@ -23,7 +22,7 @@ import org.gradle.work.DisableCachingByDefault
 abstract class MpsExecute : JavaExec() {
 
     @get:Input
-    val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
+    abstract val logLevel: Property<LogLevel>
 
     @get:Internal
     abstract val mpsHome: DirectoryProperty
@@ -56,6 +55,7 @@ abstract class MpsExecute : JavaExec() {
     val additionalExecuteBackendClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
 
     init {
+        logLevel.convention(project.gradle.startParameter.logLevel)
         mpsVersion.convention(MpsVersionDetection.fromMpsHome(project.layout, providerFactory, mpsHome.asFile))
         projectLocation.convention(project.layout.projectDirectory)
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
@@ -25,7 +25,7 @@ import org.gradle.process.CommandLineArgumentProvider
 @Incubating
 abstract class MpsGenerate : JavaExec() {
 
-    @get:Internal
+    @get:Input
     val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal("covered by mpsVersion, classpath")

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
@@ -10,6 +10,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -23,6 +24,9 @@ import org.gradle.process.CommandLineArgumentProvider
 @CacheableTask
 @Incubating
 abstract class MpsGenerate : JavaExec() {
+
+    @get:Internal
+    val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal("covered by mpsVersion, classpath")
     val mpsHome: DirectoryProperty = objectFactory.directoryProperty()
@@ -110,7 +114,7 @@ abstract class MpsGenerate : JavaExec() {
             result.addAll(excludeModels.get().map { "--exclude-model=$it" })
             result.addAll(excludeModules.get().map { "--exclude-module=$it" })
 
-            addLogLevel(result)
+            addLogLevel(result, logLevel.get())
 
             if (!strictMode.get()) {
                 result.add("--no-strict-mode")

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
@@ -114,7 +114,9 @@ abstract class MpsGenerate : JavaExec() {
             result.addAll(excludeModels.get().map { "--exclude-model=$it" })
             result.addAll(excludeModules.get().map { "--exclude-module=$it" })
 
-            addLogLevel(result, logLevel.get())
+            if (logLevel.get() <= LogLevel.INFO) {
+                result.add("--log-level=${logLevel.get()}")
+            }
 
             if (!strictMode.get()) {
                 result.add("--no-strict-mode")

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsMigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsMigrate.kt
@@ -145,7 +145,9 @@ abstract class MpsMigrate @Inject constructor(
 
                         if (mpsVersion.get() >= "2022.3") { add("jnaLibraryPath" to "lib/jna/${computeJnaArch()}") }
 
-                        addIfInfoLogLevel(this, logLevel.get(), "loglevel" to "info")
+                        if (logLevel.get() <= LogLevel.INFO) {
+                            add("loglevel" to "info")
+                        }
 
                         toTypedArray()
                     }

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsMigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsMigrate.kt
@@ -2,7 +2,6 @@ package de.itemis.mps.gradle.tasks
 
 import de.itemis.mps.gradle.TaskGroups
 import de.itemis.mps.gradle.launcher.MpsVersionDetection
-import de.itemis.mps.gradle.runAnt
 import groovy.xml.MarkupBuilder
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -21,7 +20,6 @@ import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.withGroovyBuilder
-import org.gradle.platform.Architecture
 import java.io.File
 import javax.inject.Inject
 
@@ -30,6 +28,9 @@ abstract class MpsMigrate @Inject constructor(
     objectFactory: ObjectFactory,
     providerFactory: ProviderFactory
 ) : DefaultTask() {
+
+    @get:Internal
+    val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal
     val mpsHome: DirectoryProperty = objectFactory.directoryProperty()
@@ -144,7 +145,7 @@ abstract class MpsMigrate @Inject constructor(
 
                         if (mpsVersion.get() >= "2022.3") { add("jnaLibraryPath" to "lib/jna/${computeJnaArch()}") }
 
-                        addIfInfoLogLevel(this, "loglevel" to "info")
+                        addIfInfoLogLevel(this, logLevel.get(), "loglevel" to "info")
 
                         toTypedArray()
                     }

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsMigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsMigrate.kt
@@ -29,7 +29,7 @@ abstract class MpsMigrate @Inject constructor(
     providerFactory: ProviderFactory
 ) : DefaultTask() {
 
-    @get:Internal
+    @get:Input
     val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
@@ -29,7 +29,7 @@ open class Remigrate @Inject constructor(
     providerFactory: ProviderFactory
 ) : JavaExec() {
 
-    @get:Internal
+    @get:Input
     val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
@@ -8,6 +8,7 @@ import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -27,6 +28,9 @@ open class Remigrate @Inject constructor(
     objectFactory: ObjectFactory,
     providerFactory: ProviderFactory
 ) : JavaExec() {
+
+    @get:Internal
+    val logLevel: Property<LogLevel> = objectFactory.property<LogLevel>().convention(project.gradle.startParameter.logLevel)
 
     @get:Internal
     val mpsHome: DirectoryProperty = objectFactory.directoryProperty()
@@ -76,7 +80,7 @@ open class Remigrate @Inject constructor(
             }
 
             addPluginRoots(result, pluginRoots)
-            addLogLevel(result)
+            addLogLevel(result, logLevel.get())
             addFolderMacros(result, folderMacros)
 
             val pluginFile = backendConfig.get().resolvedConfiguration.firstLevelModuleDependencies

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
@@ -80,7 +80,11 @@ open class Remigrate @Inject constructor(
             }
 
             addPluginRoots(result, pluginRoots)
-            addLogLevel(result, logLevel.get())
+
+            if (logLevel.get() <= LogLevel.INFO) {
+                result.add("--log-level=${logLevel.get()}")
+            }
+
             addFolderMacros(result, folderMacros)
 
             val pluginFile = backendConfig.get().resolvedConfiguration.firstLevelModuleDependencies

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
@@ -2,24 +2,11 @@ package de.itemis.mps.gradle.tasks
 
 import de.itemis.mps.gradle.ErrorMessages
 import org.gradle.api.GradleException
-import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileSystemLocation
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Provider
 import java.io.File
-
-internal fun Task.addLogLevel(args: MutableCollection<String>, logLevel: LogLevel) = addIfInfoLogLevel(args, logLevel,"--log-level=info")
-
-/**
- * A weird overload, usable for building a map of Ant task attributes, as well as a list of command line backend
- * attributes.
- */
-internal fun <T> Task.addIfInfoLogLevel(result: MutableCollection<T>, logLevel: LogLevel, value: T) {
-    val effectiveLogLevel = logging.level ?: logLevel
-    if (effectiveLogLevel <= LogLevel.INFO) result.add(value)
-}
 
 internal fun checkProjectLocation(projectLocation: Provider<out FileSystemLocation>) =
     checkProjectLocation(projectLocation.get().asFile)

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
@@ -10,14 +10,14 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Provider
 import java.io.File
 
-internal fun Task.addLogLevel(args: MutableCollection<String>) = addIfInfoLogLevel(args, "--log-level=info")
+internal fun Task.addLogLevel(args: MutableCollection<String>, logLevel: LogLevel) = addIfInfoLogLevel(args, logLevel,"--log-level=info")
 
 /**
  * A weird overload, usable for building a map of Ant task attributes, as well as a list of command line backend
  * attributes.
  */
-internal fun <T> Task.addIfInfoLogLevel(result: MutableCollection<T>, value: T) {
-    val effectiveLogLevel = logging.level ?: LogLevel.LIFECYCLE
+internal fun <T> Task.addIfInfoLogLevel(result: MutableCollection<T>, logLevel: LogLevel, value: T) {
+    val effectiveLogLevel = logging.level ?: logLevel
     if (effectiveLogLevel <= LogLevel.INFO) result.add(value)
 }
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
@@ -17,7 +17,7 @@ internal fun Task.addLogLevel(args: MutableCollection<String>) = addIfInfoLogLev
  * attributes.
  */
 internal fun <T> Task.addIfInfoLogLevel(result: MutableCollection<T>, value: T) {
-    val effectiveLogLevel = logging.level ?: project.gradle.startParameter.logLevel
+    val effectiveLogLevel = logging.level ?: LogLevel.LIFECYCLE
     if (effectiveLogLevel <= LogLevel.INFO) result.add(value)
 }
 


### PR DESCRIPTION
The docs tell us to only use `Task.logging`, Im not sure what the actual intent of this function was, so I simply removed this bit.

- https://docs.gradle.org/current/userguide/upgrading_version_8.html#task_project
- https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution