### PR TITLE
Use Gradle Version Catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/generate-build-solution/mps-prj/solutions/my.build/build.xml
 workspace.xml
 **/*_gen*/
 .gradle
+.ideaconfig

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,24 +7,18 @@ buildscript {
     }
 
     dependencies {
-        classpath("de.itemis.mps.gradle:git-based-versioning")
+        classpath(libs.itemis.gradle.git.based.versioning)
     }
 }
-
-val kotlinApiVersion by extra { "1.7" }
-val kotlinVersion by extra { "$kotlinApiVersion.10" }
-
 
 plugins {
     groovy
     `java-gradle-plugin`
     `kotlin-dsl`
     `maven-publish`
-    kotlin("jvm") version "1.7.10"
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
+    kotlin("jvm") version libs.versions.kotlin
+    alias(libs.plugins.kotlin.compatibility.validator)
 }
-
-val baseVersion = "1.29.2"
 
 group = "de.itemis.mps"
 
@@ -35,14 +29,14 @@ version = if (!project.hasProperty("useSnapshot") &&
 ) {
     val prefix = when (currentBranch) {
         null, "", "v1.x", "HEAD", "master", "main" -> ""
-        else -> "$currentBranch."
+        else -> "${libs.versions.baseVersion.get()}."
     }
 
     val suffix = ".${GitBasedVersioning.getGitCommitCount()}.${GitBasedVersioning.getGitShortCommitHash()}"
 
-    prefix + baseVersion + suffix
+    prefix + libs.versions.baseVersion.get() + suffix
 } else {
-    "$baseVersion-SNAPSHOT"
+    "${libs.versions.baseVersion.get()}-SNAPSHOT"
 }
 
 val mpsConfiguration = configurations.create("mps")
@@ -58,11 +52,11 @@ dependencyLocking {
 }
 
 dependencies {
-    api("de.itemis.mps.gradle:git-based-versioning")
-    implementation(kotlin("stdlib", version = kotlinVersion))
-    implementation("net.swiftzer.semver:semver:1.1.2")
-    implementation("de.itemis.mps.build-backends:launcher:2.4.0.+")
-    testImplementation("junit:junit:4.13.2")
+    api(libs.itemis.gradle.git.based.versioning)
+    implementation(kotlin("stdlib", version = libs.versions.kotlin.get()))
+    implementation(libs.swiftzer.semver)
+    implementation(libs.itemis.gradle.build.backends.launcher)
+    testImplementation(libs.junit)
 }
 
 tasks.test {
@@ -151,8 +145,8 @@ java {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
-    kotlinOptions.apiVersion = kotlinApiVersion
+    kotlinOptions.jvmTarget = libs.versions.kotlinJVMtarget.get()
+    kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
     kotlinOptions.allWarningsAsErrors = true
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath(libs.itemis.gradle.git.based.versioning)
+        classpath("de.itemis.mps.gradle:git-based-versioning")
     }
 }
 
@@ -20,6 +20,8 @@ plugins {
     alias(libs.plugins.kotlin.compatibility.validator)
 }
 
+val baseVersion = "1.29.1"
+
 group = "de.itemis.mps"
 
 val currentBranch : String? = GitBasedVersioning.getGitBranch()
@@ -29,14 +31,14 @@ version = if (!project.hasProperty("useSnapshot") &&
 ) {
     val prefix = when (currentBranch) {
         null, "", "v1.x", "HEAD", "master", "main" -> ""
-        else -> "${libs.versions.baseVersion.get()}."
+        else -> "$currentBranch."
     }
 
     val suffix = ".${GitBasedVersioning.getGitCommitCount()}.${GitBasedVersioning.getGitShortCommitHash()}"
 
-    prefix + libs.versions.baseVersion.get() + suffix
+    prefix + currentBranch + suffix
 } else {
-    "${libs.versions.baseVersion.get()}-SNAPSHOT"
+    "$currentBranch-SNAPSHOT"
 }
 
 val mpsConfiguration = configurations.create("mps")
@@ -145,7 +147,7 @@ java {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = libs.versions.kotlinJVMtarget.get()
+    kotlinOptions.jvmTarget = libs.versions.kotlinJvmTarget.get()
     kotlinOptions.apiVersion = libs.versions.kotlinApi.get()
     kotlinOptions.allWarningsAsErrors = true
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ version = if (!project.hasProperty("useSnapshot") &&
 ) {
     val prefix = when (currentBranch) {
         null, "", "v1.x", "HEAD", "master", "main" -> ""
-        else -> "$baseVersion."
+        else -> "$currentBranch."
     }
 
     val suffix = ".${GitBasedVersioning.getGitCommitCount()}.${GitBasedVersioning.getGitShortCommitHash()}"
@@ -55,7 +55,7 @@ dependencyLocking {
 
 dependencies {
     api(libs.itemis.gradle.git.based.versioning)
-    implementation(kotlin("stdlib", version = libs.versions.kotlin.get()))
+    implementation(libs.kotlin.stdlib)
     implementation(libs.swiftzer.semver)
     implementation(libs.itemis.gradle.build.backends.launcher)
     testImplementation(libs.junit)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     alias(libs.plugins.kotlin.compatibility.validator)
 }
 
-val baseVersion = "1.29.1"
+val baseVersion = "1.29.2"
 
 group = "de.itemis.mps"
 
@@ -31,14 +31,14 @@ version = if (!project.hasProperty("useSnapshot") &&
 ) {
     val prefix = when (currentBranch) {
         null, "", "v1.x", "HEAD", "master", "main" -> ""
-        else -> "$currentBranch."
+        else -> "$baseVersion."
     }
 
     val suffix = ".${GitBasedVersioning.getGitCommitCount()}.${GitBasedVersioning.getGitShortCommitHash()}"
 
-    prefix + currentBranch + suffix
+    prefix + baseVersion + suffix
 } else {
-    "$currentBranch-SNAPSHOT"
+    "$baseVersion-SNAPSHOT"
 }
 
 val mpsConfiguration = configurations.create("mps")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,27 @@
+[versions]
+# this is our own version we deploy
+baseVersion =  "1.29.2"
+
+#versions
+kotlinApi = "1.7"
+kotlin = "1.7.10"
+kotlinJVMtarget = "1.8"
+
+# plugins
+kotlinCompatibilityValidator = "0.13.2"
+
+# libraries
+semver = "1.1.2"
+junit = "4.13.2"
+
+git-based-versioning = "*"
+buildBackends = "2.4.0+"
+
+[plugins]
+kotlin-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinCompatibilityValidator" }
+
+[libraries]
+swiftzer-semver = {group = "net.swiftzer.semver", name="semver", version.ref="semver"}
+junit = {group = "junit", name="junit", version.ref="junit"}
+itemis-gradle-git-based-versioning = {group= "de.itemis.mps.gradle", name = "git-based-versioning", version.ref="git-based-versioning"}
+itemis-gradle-build-backends-launcher = {group = "de.itemis.mps.build-backends", name="launcher", version.ref="buildBackends"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ buildBackends = "2.4.0.+"
 kotlin-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinCompatibilityValidator" }
 
 [libraries]
+kotlin-stdlib = {group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin"}
 swiftzer-semver = {group = "net.swiftzer.semver", name="semver", version.ref="semver"}
 junit = {group = "junit", name="junit", version.ref="junit"}
 itemis-gradle-git-based-versioning = {group= "de.itemis.mps.gradle", name = "git-based-versioning", version.ref="gitBasedVersioning"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,8 @@
 [versions]
-# this is our own version we deploy
-baseVersion =  "1.29.2"
-
 #versions
 kotlinApi = "1.7"
 kotlin = "1.7.10"
-kotlinJVMtarget = "1.8"
+kotlinJvmTarget = "1.8"
 
 # plugins
 kotlinCompatibilityValidator = "0.13.2"
@@ -13,9 +10,8 @@ kotlinCompatibilityValidator = "0.13.2"
 # libraries
 semver = "1.1.2"
 junit = "4.13.2"
-
-git-based-versioning = "*"
-buildBackends = "2.4.0+"
+gitBasedVersioning = "*"
+buildBackends = "2.4.0.+"
 
 [plugins]
 kotlin-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinCompatibilityValidator" }
@@ -23,5 +19,5 @@ kotlin-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibil
 [libraries]
 swiftzer-semver = {group = "net.swiftzer.semver", name="semver", version.ref="semver"}
 junit = {group = "junit", name="junit", version.ref="junit"}
-itemis-gradle-git-based-versioning = {group= "de.itemis.mps.gradle", name = "git-based-versioning", version.ref="git-based-versioning"}
+itemis-gradle-git-based-versioning = {group= "de.itemis.mps.gradle", name = "git-based-versioning", version.ref="gitBasedVersioning"}
 itemis-gradle-build-backends-launcher = {group = "de.itemis.mps.build-backends", name="launcher", version.ref="buildBackends"}


### PR DESCRIPTION
This is the first PR in a series of PRs to move the plugin towards a v3, see #169.

Using the Gradle Version Catalog is the basis to migrate parts of PR #161 into the plugin.
