### PR TITLE
Fix and update GitHub Actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,32 +15,28 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         java: [ 11, 17 ]
-
     steps:
       - uses: actions/checkout@v4
-
       # Java 11 is always needed to run the tests because they use MPS 2021.x
       - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11
-
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
-
       - uses: gradle/actions/setup-gradle@v3
-
       - name: Build with Gradle
         run: ./gradlew build
-
       - name: Upload JUnit XMLs
         uses: actions/upload-artifact@v4
         if: failure()
@@ -48,7 +44,6 @@ jobs:
           name: junit-xmls
           path: '**/build/test-results/**/TEST-*.xml'
           retention-days: 7
-
       - uses: mikepenz/action-junit-report@v5
         if: success() || failure()
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    name: Builld (JDK ${{ matrix.java }})
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,9 +13,13 @@ on:
       - 'v1.x'
       - 'master'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
-    name: Builld (JDK ${{ matrix.java }})
+    name: Build (JDK ${{ matrix.java }})
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
     strategy:
       matrix:
         java: [ 11, 17, 21 ]
@@ -54,3 +53,5 @@ jobs:
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'
           require_tests: true
+          summary: true
+          annotate_only: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,7 +3,15 @@
 
 name: Java CI with Gradle
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - 'v1.x'
+      - 'master'
+  pull_request:
+    branches:
+      - 'v1.x'
+      - 'master'
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,7 +3,7 @@
 
 name: Java CI with Gradle
 
-on: [push]
+on: [ push ]
 
 jobs:
   build:
@@ -11,34 +11,38 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17]
+        java: [ 11, 17 ]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    # Java 11 is always needed to run the tests because they use MPS 2021.x
-    - name: Set up Java 11
-      uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: 11
+      # Java 11 is always needed to run the tests because they use MPS 2021.x
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
 
-    - uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: ${{ matrix.java }}
-    - uses: gradle/gradle-build-action@v2
-    - name: Build with Gradle
-      run: ./gradlew build
-    - name: Upload JUnit XMLs
-      uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: junit-xmls
-        path: '**/build/test-results/**/TEST-*.xml'
-        retention-days: 7
-    - uses: mikepenz/action-junit-report@v4
-      if: success() || failure()
-      with:
-        report_paths: '**/build/test-results/**/TEST-*.xml'
-        require_tests: true
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+
+      - uses: gradle/actions/setup-gradle@v3
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Upload JUnit XMLs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: junit-xmls
+          path: '**/build/test-results/**/TEST-*.xml'
+          retention-days: 7
+
+      - uses: mikepenz/action-junit-report@v5
+        if: success() || failure()
+        with:
+          report_paths: '**/build/test-results/**/TEST-*.xml'
+          require_tests: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
       checks: write
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
     steps:
       - uses: actions/checkout@v4
       # Java 11 is always needed to run the tests because they use MPS 2021.x


### PR DESCRIPTION
Fixes the workflow by updating the deprecated `actions/upload-artifact@v3` action and updating other actions too while we are at it.