### PR TITLE
Fix debug log level for backend tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.30.2
+
+### Fixed
+
+- Tasks no longer crash due to an invalid log level when Gradle is run with `--debug`.
+
 ## 1.30.1
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     alias(libs.plugins.kotlin.compatibility.validator)
 }
 
-val baseVersion = "1.30.1"
+val baseVersion = "1.30.2"
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
@@ -134,9 +134,7 @@ abstract class MpsCheck : JavaExec(), VerificationTask {
                 result.add("--parallel")
             }
 
-            if (logLevel.get() <= LogLevel.INFO) {
-                result.add("--log-level=${logLevel.get()}")
-            }
+            addLogLevel(result, logLevel)
 
             result
         })

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsExecute.kt
@@ -76,9 +76,7 @@ abstract class MpsExecute : JavaExec() {
                 add("--method=${method.get()}")
                 methodArguments.get().forEach { add("--arg=$it") }
 
-                if (logLevel.get() <= LogLevel.INFO) {
-                    add("--log-level=${logLevel.get()}")
-                }
+                addLogLevel(this, logLevel)
             }
         }
 

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsGenerate.kt
@@ -114,9 +114,7 @@ abstract class MpsGenerate : JavaExec() {
             result.addAll(excludeModels.get().map { "--exclude-model=$it" })
             result.addAll(excludeModules.get().map { "--exclude-module=$it" })
 
-            if (logLevel.get() <= LogLevel.INFO) {
-                result.add("--log-level=${logLevel.get()}")
-            }
+            addLogLevel(result, logLevel)
 
             if (!strictMode.get()) {
                 result.add("--no-strict-mode")

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/Remigrate.kt
@@ -80,11 +80,7 @@ open class Remigrate @Inject constructor(
             }
 
             addPluginRoots(result, pluginRoots)
-
-            if (logLevel.get() <= LogLevel.INFO) {
-                result.add("--log-level=${logLevel.get()}")
-            }
-
+            addLogLevel(result, logLevel)
             addFolderMacros(result, folderMacros)
 
             val pluginFile = backendConfig.get().resolvedConfiguration.firstLevelModuleDependencies

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/backend_arguments.kt
@@ -5,6 +5,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Provider
 import java.io.File
 
@@ -31,4 +32,12 @@ internal fun addFolderMacros(result: MutableCollection<String>, folderMacros: Pr
 
 internal fun addVarMacros(result: MutableCollection<String>, varMacros: Provider<Map<String, String>>) {
     varMacros.get().mapTo(result) { "--macro=${it.key}::${it.value}" }
+}
+
+internal fun addLogLevel(result: MutableCollection<String>, logLevel: Provider<LogLevel>) {
+    when (logLevel.get()) {
+        LogLevel.INFO -> result.add("--log-level=INFO")
+        LogLevel.DEBUG -> result.add("--log-level=ALL")
+        else -> {}
+    }
 }


### PR DESCRIPTION
- centralize backend log-level argument handling across MPS check, execute, generate, and remigrate tasks
- map Gradle `DEBUG` to the backend-supported `ALL` level while preserving `INFO` behavior