### PR TITLE
1.31.0: avoid duplicate action registration errors on 2025.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.31.0
+
+### Changed
+
+- Minimum version of mps-build-backends raised to 1.26.0.
+
+### Fixed
+
+- `MpsCheck`: avoid duplicate action registration errors with MPS 2025.1 and above.
+
 ## 1.30.2
 
 ### Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     alias(libs.plugins.kotlin.compatibility.validator)
 }
 
-val baseVersion = "1.30.2"
+val baseVersion = "1.31.0"
 
 group = "de.itemis.mps"
 

--- a/src/main/kotlin/de/itemis/mps/gradle/Common.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/Common.kt
@@ -15,7 +15,7 @@ private val logger = Logger.getLogger("de.itemis.mps.gradle.common")
 
 const val MPS_SUPPORT_MSG = ErrorMessages.MPS_VERSION_NOT_SUPPORTED
 
-const val MPS_BUILD_BACKENDS_VERSION = "[1.15,2.0)" // 1.15 required for --plugin-root support.
+const val MPS_BUILD_BACKENDS_VERSION = "[1.26,2.0)" // 1.26 required to run modelcheck without plugins on its classpath
 
 data class Plugin(
         var id: String,

--- a/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/modelcheck/Plugin.kt
@@ -104,18 +104,6 @@ open class ModelcheckMpsProjectPlugin : Plugin<Project> {
                         maxHeapSize = extension.maxHeap!!
                     }
                     classpath(fileTree(File(mpsLocation, "/lib")).include("**/*.jar"))
-                    // add only minimal number of plugins jars that are required by the modelcheck code
-                    // (to avoid conflicts with plugin classloader if custom configured plugins are loaded)
-                    // mps-httpsupport: we need it to print the node url to the console.
-                    // mps-modelchecker: contains used UnresolvedReferencesChecker
-                    // git4idea: has to be on classpath as bundled plugin to be loaded (since 2019.3)
-                    classpath(
-                        fileTree(File(mpsLocation, "/plugins")).include(
-                            "mps-modelchecker/**/*.jar",
-                            "mps-httpsupport/**/*.jar",
-                            "git4idea/**/*.jar"
-                        )
-                    )
                     classpath(genConfig)
                     debug = extension.debug
                     mainClass.set("de.itemis.mps.gradle.modelcheck.MainKt")

--- a/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
+++ b/src/main/kotlin/de/itemis/mps/gradle/tasks/MpsCheck.kt
@@ -141,7 +141,7 @@ abstract class MpsCheck : JavaExec(), VerificationTask {
 
         group = TaskGroups.VERIFICATION
 
-        classpath(mpsAndPluginJars())
+        classpath(mpsJars())
         classpath(project.configurations.named(BackendConfigurations.MODELCHECK_BACKEND_CONFIGURATION_NAME))
         classpath(additionalModelcheckBackendClasspath)
 
@@ -153,16 +153,7 @@ abstract class MpsCheck : JavaExec(), VerificationTask {
         super.exec()
     }
 
-    private fun mpsAndPluginJars() = mpsHome.asFileTree.matching {
+    private fun mpsJars() = mpsHome.asFileTree.matching {
         include("lib/**/*.jar")
-
-        // add only minimal number of plugins jars that are required by the modelcheck code
-        // (to avoid conflicts with plugin classloader if custom configured plugins are loaded)
-        // mps-httpsupport: we need it to print the node url to the console.
-        // mps-modelchecker: contains used UnresolvedReferencesChecker
-        // git4idea: has to be on classpath as bundled plugin to be loaded (since 2019.3)
-        include("plugins/mps-modelchecker/**/*.jar")
-        include("plugins/mps-httpsupport/**/*.jar")
-        include("plugins/git4idea/**/*.jar")
     }
 }

--- a/src/test/kotlin/test/modelchecking/ModelCheckWithPluginTest.kt
+++ b/src/test/kotlin/test/modelchecking/ModelCheckWithPluginTest.kt
@@ -137,7 +137,7 @@ class ModelCheckWithPluginTest {
         settingsFile.writeText(settingsBoilerplate())
 
         buildFile.writeText(
-            buildScriptBoilerplate("2022.2.2") +
+            buildScriptBoilerplate("2025.1.3") +
             """
                 modelcheck {
                     projectLocation = file("${mpsTestPrjLocation.toPath()}")

--- a/src/test/kotlin/test/modelchecking/MpsCheckTaskTest.kt
+++ b/src/test/kotlin/test/modelchecking/MpsCheckTaskTest.kt
@@ -4,14 +4,18 @@ import de.itemis.mps.gradle.ErrorMessages
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import support.extractTestProject
+import java.io.File
 
 class MpsCheckTaskTest {
+    val mpsVersion = "2025.1.3"
+
     @Rule
     @JvmField
     val testProjectDir: TemporaryFolder = TemporaryFolder()
@@ -22,7 +26,7 @@ class MpsCheckTaskTest {
         }
     """.trimIndent()
 
-    private fun buildScriptBoilerplate(mpsVersion: String) = """
+    private fun buildScriptBoilerplate() = """
             import de.itemis.mps.gradle.tasks.MpsCheck
 
             plugins {
@@ -55,7 +59,7 @@ class MpsCheckTaskTest {
         extractTestProject("test-project", mpsTestPrjLocation)
 
         settingsFile.writeText(settingsScriptBoilerplate())
-        buildFile.writeText(buildScriptBoilerplate("2021.3.3") + """
+        buildFile.writeText(buildScriptBoilerplate() + """
             val checkProject by tasks.registering(MpsCheck::class) {
                 mpsHome.set(layout.dir(resolveMps.map { it.destinationDir }))
                 junitFile.set(layout.buildDirectory.file("output.xml"))
@@ -77,7 +81,7 @@ class MpsCheckTaskTest {
         extractTestProject("test-project", mpsTestPrjLocation)
 
         settingsFile.writeText(settingsScriptBoilerplate())
-        buildFile.writeText(buildScriptBoilerplate("2021.3.3") + """
+        buildFile.writeText(buildScriptBoilerplate() + """
             val checkProject by tasks.registering(MpsCheck::class) {
                 mpsHome.set(layout.dir(resolveMps.map { it.destinationDir }))
                 projectLocation.set(file("mps-prj"))
@@ -89,7 +93,58 @@ class MpsCheckTaskTest {
         val result = gradleRunner().withArguments("checkProject").build()
 
         Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":checkProject")?.outcome)
+        assertThat("no duplicate actions", result.output, not(containsString("Cannot add an action twice")))
         Assert.assertTrue("output file must exist", testProjectDir.root.resolve("build/output.xml").isFile)
+    }
+
+    @Test
+    fun noDuplicateActions() {
+        val settingsFile = testProjectDir.newFile("settings.gradle.kts")
+        val buildFile = testProjectDir.newFile("build.gradle.kts")
+        val mpsTestPrjLocation = testProjectDir.newFolder("mps-prj")
+
+        extractTestProject("test-project", mpsTestPrjLocation)
+
+        settingsFile.writeText(settingsScriptBoilerplate())
+        buildFile.writeText(buildScriptBoilerplate() + """
+            val checkProject by tasks.registering(MpsCheck::class) {
+                mpsHome.set(layout.dir(resolveMps.map { it.destinationDir }))
+                projectLocation.set(file("mps-prj"))
+                junitFile.set(layout.buildDirectory.file("output.xml"))
+            }
+        """.trimIndent())
+
+        val result = gradleRunner().withArguments("checkProject").build()
+
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":checkProject")?.outcome)
+        assertThat("no duplicate actions", result.output, not(containsString("Cannot add an action twice")))
+        Assert.assertTrue("output file must exist", testProjectDir.root.resolve("build/output.xml").isFile)
+    }
+
+    @Test
+    fun failsOnErrors() {
+        val settingsFile = testProjectDir.newFile("settings.gradle.kts")
+        val buildFile = testProjectDir.newFile("build.gradle.kts")
+        val mpsTestPrjLocation = testProjectDir.newFolder("mps-prj")
+        val junitFile = testProjectDir.root.resolve("build/output.xml")
+
+        extractTestProject("test-project-with-errors", mpsTestPrjLocation)
+
+        settingsFile.writeText(settingsScriptBoilerplate())
+        buildFile.writeText(buildScriptBoilerplate() + """
+            val checkProject by tasks.registering(MpsCheck::class) {
+                mpsHome.set(layout.dir(resolveMps.map { it.destinationDir }))
+                projectLocation.set(file("mps-prj"))
+                junitFile.set(layout.buildDirectory.file("output.xml"))
+            }
+        """.trimIndent())
+
+        val result = gradleRunner()
+            .withArguments("checkProject")
+            .forwardOutput()
+            .buildAndFail()
+        Assert.assertEquals(TaskOutcome.FAILED, result.task(":checkProject")?.outcome)
+        Assert.assertTrue("JUnit-formatted results file should exist", junitFile.exists())
     }
 
     @Test
@@ -102,7 +157,7 @@ class MpsCheckTaskTest {
         extractTestProject("test-project", mpsTestPrjLocation)
 
         settingsFile.writeText(settingsScriptBoilerplate())
-        buildFile.writeText(buildScriptBoilerplate("2021.3.3") + """
+        buildFile.writeText(buildScriptBoilerplate() + """
             val checkProject by tasks.registering(MpsCheck::class) {
                 mpsHome.set(layout.dir(resolveMps.map { it.destinationDir }))
                 projectLocation.set(file("mps-prj"))


### PR DESCRIPTION
Use mps-build-backends 1.26.0 and above to run model checker without any plugins on the classpath. This fixes 'duplicate action' errors on MPS 2025.1 and above.